### PR TITLE
fix: prevent longest recording cache from being desynced and playback from being desynced

### DIFF
--- a/interface/dummyBotsAndReplay/replay/replay.del
+++ b/interface/dummyBotsAndReplay/replay/replay.del
@@ -118,3 +118,17 @@ if (EventPlayer().replayState == ReplayState.PLAYING)
 {
   StopClip();
 }
+
+rule: "[interface/dummyBotsAndReplay/replay/replay.del] Update longest recording length when player joins"
+Event.OnPlayerJoin
+{
+  # Wait for a bit to avoid overloading the server
+  Wait(0.1);
+  UpdateLongestRecordingLength();
+}
+
+rule: "[interface/dummyBotsAndReplay/replay/replay.del] Update longest recording length when player leaves"
+Event.OnPlayerLeave
+{
+  UpdateLongestRecordingLength();
+}

--- a/interface/dummyBotsAndReplay/replay/replayDefs.del
+++ b/interface/dummyBotsAndReplay/replay/replayDefs.del
@@ -372,10 +372,10 @@ void PlayClip() playervar "[SUB | interface/dummyBotsAndReplay/replay/replayDefs
   StopClip();
   StopForcingHero(EventPlayer());
   Respawn();
-  WaitUntil(HeroOf() != recordingHero, 0.25);
+  Wait(0.25);
   ForcePlayerHero(EventPlayer(), recordingHero);
   Wait(0.064);
-  TeleportPlayerToResetPoint(EventPlayer(), EventPlayer().replayResetPoint);
+  TeleportPlayerToResetPoint_CONSTANT_TIME(EventPlayer(), EventPlayer().replayResetPoint);
   if (waitingOnPlayer != null) {
     WaitUntil(waitingOnPlayer.replayState == ReplayState.RECORDING, 3);
   } else {
@@ -412,10 +412,10 @@ void LoopClip() playervar "[SUB | interface/dummyBotsAndReplay/replay/replayDefs
   currentEventFrames = [];
   StopForcingHero(EventPlayer());
   Respawn();
-  WaitUntil(HeroOf() != recordingHero, 0.25);
+  Wait(0.25);
   ForcePlayerHero(EventPlayer(), recordingHero);
   // Wait(0.064);
-  TeleportPlayerToResetPoint(EventPlayer(), EventPlayer().replayResetPoint);
+  TeleportPlayerToResetPoint_CONSTANT_TIME(EventPlayer(), EventPlayer().replayResetPoint);
   Wait(0.5);
   botReadyToReplay = true;
 }

--- a/lib/player/resetPoint.del
+++ b/lib/player/resetPoint.del
@@ -18,3 +18,15 @@ void TeleportPlayerToResetPoint(in Player p, in ResetPoint resetPoint) {
   WaitUntil(AngleBetweenVectors(FacingDirectionOf(p), resetPoint.facing) < 0.1, 0.25);
   StopFacing(p);
 }
+
+void TeleportPlayerToResetPoint_CONSTANT_TIME(in Player p, in ResetPoint resetPoint) {
+  Teleport(p, resetPoint.location);
+  StopFacing(p);
+  MinWait();
+  SetFacing(p, resetPoint.facing, Relative.ToWorld);
+  # Because for SOME REASON setting FACING and TELEPORTING in the SAME FRAME cancels the TELEPORT
+  Wait(0.032);
+  StartFacing(p, resetPoint.facing, 1000, Relative.ToWorld);
+  Wait(0.25);
+  StopFacing(p);
+}


### PR DESCRIPTION
This PR fixes two bugs with replay playback. See below.

Commits:
- **fix: prevent longest recording length from becoming inaccurate when a bot is deleted or is replaced**
- **fix: prevent bot replays from being desynced**
