### PR TITLE
refactor: recreate dummy bot when changing hero

### DIFF
--- a/interface/dummyBotsAndReplay/botEditPage.del
+++ b/interface/dummyBotsAndReplay/botEditPage.del
@@ -162,16 +162,6 @@ if (selectedBotEditAction == BotEditAction.CHANGE_HERO)
   LoadTempDataToSelectedBot();
 }
 
-rule: "[interface/dummyBotsAndReplay/botEditPage.del] BUGFIX: When dummy bot respawns, force it back onto the right hero"
-Event.OnDeath
-if (IsDummyBot())
-{
-  tempHeroStorage = HeroOf();
-  StopForcingHero(EventPlayer());
-  WaitUntil(IsAlive(), 10000000);
-  WaitUntil(HeroOf() != tempHeroStorage, 1);
-  ForcePlayerHero(EventPlayer(), tempHeroStorage);
-}
 
 rule: "[interface/dummyBotsAndReplay/botEditPage.del] Change team"
 Event.OngoingPlayer

--- a/interface/dummyBotsAndReplay/botEditPage.del
+++ b/interface/dummyBotsAndReplay/botEditPage.del
@@ -78,60 +78,26 @@ if (selectedBot != null)
   LoopIfConditionIsTrue();
 }
 
-playervar Hero tempHeroStorage;
-rule: "[interface/dummyBotsAndReplay/botEditPage.del] Change hero"
-Event.OngoingPlayer
-if (selectedBotEditAction == BotEditAction.CHANGE_HERO)
-{
-  tempHeroStorage = HeroOf();
-  SetAllowedHeroes(EventPlayer(), AllHeroes().Remove(tempHeroStorage));
-  WaitUntil(!HasSpawned(), 1);
-  ResetHeroAvailability(EventPlayer());
-  WaitUntil(HasSpawned(), 1000000);
-  ForcePlayerHero(selectedBot, HeroOf());
-  selectedBot.tempHeroStorage = HeroOf();
-  MinWait();
-  StopForcingHero(selectedBot);
-  ForcePlayerHero(EventPlayer(), tempHeroStorage);
-  MinWait();
-  StopForcingHero(EventPlayer());
-  StopForcingPlayerPosition();
-  StartForcingPlayerPosition(EventPlayer(), EventPlayer().menuActivationPoint.location, true);
-  Wait(0.064);
-  WaitUntil(DistanceBetween(EventPlayer(), EventPlayer().menuActivationPoint.location) < 0.05
-    && AngleBetweenVectors(EventPlayer().FacingDirection(), menuActivationPoint.facing) < 0.1, 1);
-  selectedControl = null;
-  CloseMenu(EventPlayer());
-}
+playervar Boolean wasPunchingBag!;
+playervar ResetPoint tempPinnedPosition!;
+playervar ResetPoint tempRespawnPoint!;
+playervar ResetPoint tempResetPoint!;
+playervar Team tempTeamStorage!;
+playervar ResetPoint tempCurrentPosition!;
 
-rule: "[interface/dummyBotsAndReplay/botEditPage.del] BUGFIX: When dummy bot respawns, force it back onto the right hero"
-Event.OnDeath
-if (IsDummyBot())
-{
-  tempHeroStorage = HeroOf();
-  StopForcingHero(EventPlayer());
-  WaitUntil(IsAlive(), 10000000);
-  WaitUntil(HeroOf() != tempHeroStorage, 1);
-  ForcePlayerHero(EventPlayer(), tempHeroStorage);
-}
-
-rule: "[interface/dummyBotsAndReplay/botEditPage.del] Change team"
-Event.OngoingPlayer
-if (selectedBotEditAction == BotEditAction.CHANGE_TEAM)
-{
-  // LogToInspector("Changing team of {0}".Format([selectedBot]));
+void StoreTempDataFromBot() playervar "[SUB | interface/dummyBotsAndReplay/botEditPage.del] Store data from bot onto player" {
   tempHeroStorage = HeroOf(selectedBot);
-  Boolean wasPunchingBag! = selectedBot.isPunchingBag;
-  ResetPoint tempPinnedPosition! = selectedBot.pinnedPosition;
-  ResetPoint tempRespawnPoint! = selectedBot.respawnPoint;
-  ResetPoint tempResetPoint! = selectedBot.replayResetPoint;
-  Team tempTeamStorage! = TeamOf(selectedBot);
-  Vector tempPositionStorage! = PositionOf(selectedBot);
-  Vector tempFacingStorage! = FacingDirectionOf(selectedBot);
+  tempCurrentPosition = NewResetFromPlayer(selectedBot);
+  wasPunchingBag = selectedBot.isPunchingBag;
+  tempPinnedPosition = selectedBot.pinnedPosition;
+  tempRespawnPoint = selectedBot.respawnPoint;
+  tempResetPoint = selectedBot.replayResetPoint;
+  tempTeamStorage = TeamOf(selectedBot);
   # Temporarily store recording on player who is performing the action
-  TransferRecording(selectedBot, EventPlayer());
-  DestroyDummyBot(selectedBot.Team(), SlotOf(selectedBot));
-  selectedBot = CreateDummyBot(tempHeroStorage, OppositeTeamOf(tempTeamStorage), -1, tempPositionStorage, tempFacingStorage);
+  if (hasRecordedClip(selectedBot)) TransferRecording(selectedBot, EventPlayer());
+}
+
+void LoadTempDataToSelectedBot() playervar "[SUB | interface/dummyBotsAndReplay/botEditPage.del] Load data from player onto bot" {
   if (wasPunchingBag) {
     MarkLastCreatedBotAsPunchingBag();
   }
@@ -162,10 +128,59 @@ if (selectedBotEditAction == BotEditAction.CHANGE_TEAM)
   }
   Wait(0.064);
   # We wait to transfer the recording to the new bot to avoid overloading the server
-  TransferRecording(EventPlayer(), selectedBot);
-  StartFacing(selectedBot, tempFacingStorage, 1000, Relative.ToWorld, FacingRev.None);
-  WaitUntil(AngleBetweenVectors(FacingDirectionOf(selectedBot), tempFacingStorage) < 0.1, 1);
-  StopFacing(selectedBot);
+  if (hasRecordedClip(EventPlayer())) TransferRecording(EventPlayer(), selectedBot);
+  Wait(0.064);
+  TeleportPlayerToResetPoint(selectedBot, tempCurrentPosition);
+}
+
+playervar Hero tempHeroStorage;
+rule: "[interface/dummyBotsAndReplay/botEditPage.del] Change hero"
+Event.OngoingPlayer
+if (selectedBotEditAction == BotEditAction.CHANGE_HERO)
+{
+  # We don't want to transfer recordings between heroes
+  if (hasRecordedClip(selectedBot)) {
+    selectedBot.recordingPlayStopFlag = RecordingAction.DELETE;
+    MinWait();
+  }
+  StoreTempDataFromBot();
+  tempHeroStorage = HeroOf();
+  SetAllowedHeroes(EventPlayer(), AllHeroes().Remove(tempHeroStorage));
+  WaitUntil(!HasSpawned(), 1);
+  ResetHeroAvailability(EventPlayer());
+  WaitUntil(HasSpawned(), 1000000);
+  DestroyDummyBot(TeamOf(selectedBot), SlotOf(selectedBot));
+  MinWait();
+  selectedBot = CreateDummyBot(HeroOf(), tempTeamStorage, -1, tempCurrentPosition.location, tempCurrentPosition.facing);
+  ForcePlayerHero(EventPlayer(), tempHeroStorage);
+  MinWait();
+  StopForcingHero(EventPlayer());
+  Wait(0.064);
+  TeleportPlayerToResetPoint(EventPlayer(), menuActivationPoint);
+  selectedControl = null;
+  CloseMenu(EventPlayer());
+  LoadTempDataToSelectedBot();
+}
+
+rule: "[interface/dummyBotsAndReplay/botEditPage.del] BUGFIX: When dummy bot respawns, force it back onto the right hero"
+Event.OnDeath
+if (IsDummyBot())
+{
+  tempHeroStorage = HeroOf();
+  StopForcingHero(EventPlayer());
+  WaitUntil(IsAlive(), 10000000);
+  WaitUntil(HeroOf() != tempHeroStorage, 1);
+  ForcePlayerHero(EventPlayer(), tempHeroStorage);
+}
+
+rule: "[interface/dummyBotsAndReplay/botEditPage.del] Change team"
+Event.OngoingPlayer
+if (selectedBotEditAction == BotEditAction.CHANGE_TEAM)
+{
+  StoreTempDataFromBot();
+  DestroyDummyBot(selectedBot.Team(), SlotOf(selectedBot));
+  selectedBot = CreateDummyBot(tempHeroStorage, OppositeTeamOf(tempTeamStorage), -1, tempCurrentPosition.location, tempCurrentPosition.facing);
+  LoadTempDataToSelectedBot();
 }
 
 playervar Any botRespawnPoint_FX_Loc!;

--- a/interface/dummyBotsAndReplay/botsMenu.ostw
+++ b/interface/dummyBotsAndReplay/botsMenu.ostw
@@ -121,11 +121,8 @@ Event.OngoingPlayer
 if (IsControllable(EventPlayer()))
 if (IsTrueForAny(AllPlayers().Filter((p) => !IsControllable(p)), ArrayElement().selectedBotsReplayAction == BotsReplayAction.RESET_BOTS))
 {
-  tempHeroStorage = HeroOf();
-  StopForcingHero();
   Respawn();
   WaitUntil(IsAlive(), 1);
-  ForcePlayerHero(EventPlayer(), tempHeroStorage);
   if (replayResetPoint.location != null) {
     TeleportPlayerToResetPoint(EventPlayer(), replayResetPoint);
   } else if (respawnPoint.location != null) {

--- a/interface/dummyBotsAndReplay/replay/replayDefs.del
+++ b/interface/dummyBotsAndReplay/replay/replayDefs.del
@@ -103,6 +103,7 @@ void UpdateLongestRecordingLength() playervar "[SUB | interface/dummyBotsAndRepl
 
 void StartRecording() playervar "[SUB | interface/dummyBotsAndReplay/replay/replayDefs.del] Start Recording" {
   DeleteRecording();
+  recordingHero = HeroOf();
   # If all bots are replaying, we need to start our recording one frame later to ensure we record at the same time as the bots
   frame = allBotsReplayDuringRecording ? - 1 : 0;
   recordingLength = 0;

--- a/interface/dummyBotsAndReplay/replay/replayDefs.del
+++ b/interface/dummyBotsAndReplay/replay/replayDefs.del
@@ -75,6 +75,8 @@ void DeleteRecording() playervar "[SUB | interface/dummyBotsAndReplay/replay/rep
   reloadEvents = [];
   throttleEvents = [];
   facingEvents = [];
+  replayResetPoint.location = null;
+  recordingHero = null;
   UpdateLongestRecordingLength();
 }
 

--- a/interface/dummyBotsAndReplay/replay/replayDefs.del
+++ b/interface/dummyBotsAndReplay/replay/replayDefs.del
@@ -375,10 +375,8 @@ playervar Player waitingOnPlayer;
 
 void PlayClip() playervar "[SUB | interface/dummyBotsAndReplay/replay/replayDefs.del] Play Clip" {
   StopClip();
-  StopForcingHero(EventPlayer());
   Respawn();
   Wait(0.25);
-  ForcePlayerHero(EventPlayer(), recordingHero);
   Wait(0.064);
   TeleportPlayerToResetPoint_CONSTANT_TIME(EventPlayer(), EventPlayer().replayResetPoint);
   if (waitingOnPlayer != null) {
@@ -416,10 +414,8 @@ void LoopClip() playervar "[SUB | interface/dummyBotsAndReplay/replay/replayDefs
   frame = 0;
   currentEventIndices = [];
   currentEventFrames = [];
-  StopForcingHero(EventPlayer());
   Respawn();
   Wait(0.25);
-  ForcePlayerHero(EventPlayer(), recordingHero);
   TeleportPlayerToResetPoint_CONSTANT_TIME(EventPlayer(), EventPlayer().replayResetPoint);
   Wait(0.5);
   botReadyToReplay = true;


### PR DESCRIPTION
This PR recreates a dummy bot instead of forcing a new hero when its hero is changed. This prevents some jank where the dummy bot changes hero when it respawns.

TODO: Remove logic which guards against dummy bots changing heroes.