### PR TITLE
fix: hide bot controls when dead

### DIFF
--- a/interface/dummyBotsAndReplay/botPlacementModule.del
+++ b/interface/dummyBotsAndReplay/botPlacementModule.del
@@ -111,7 +111,7 @@ if (HasSpawned())
   };
   # Create the facing location control orb
   CreateEffect(
-    VisibleTo: playersWhoShouldSeeControls(positionControl),
+    VisibleTo: IsAlive(EventPlayer()) && playersWhoShouldSeeControls(positionControl),
     Type: Effect.Sphere,
     Color: getClosestSelectionEntity(LocalPlayer()).Id == EvaluateOnce(nextSelectionEntityId + 1) ? Color.Orange : Color.Yellow,
     Position: UpdateEveryFrame(desiredFacingControlPosition(EventPlayer())),
@@ -119,7 +119,7 @@ if (HasSpawned())
     Reevaluation: EffectRev.VisibleToPositionAndRadius
   );
   CreateBeamEffect(
-    VisibleTo: playersWhoShouldSeeControls(facingControl),
+    VisibleTo: IsAlive(EventPlayer()) && playersWhoShouldSeeControls(facingControl),
     BeamType: BeamType.GrappleBeam,
     StartPosition: EventPlayer().EyePosition(),
     EndPosition: UpdateEveryFrame(desiredFacingControlPosition(EventPlayer())),

--- a/interface/dummyBotsAndReplay/botPlacementModule.del
+++ b/interface/dummyBotsAndReplay/botPlacementModule.del
@@ -121,7 +121,7 @@ if (HasSpawned())
   CreateBeamEffect(
     VisibleTo: IsAlive(EventPlayer()) && playersWhoShouldSeeControls(facingControl),
     BeamType: BeamType.GrappleBeam,
-    StartPosition: EventPlayer().EyePosition(),
+    StartPosition: UpdateEveryFrame(EventPlayer().EyePosition()),
     EndPosition: UpdateEveryFrame(desiredFacingControlPosition(EventPlayer())),
     Color: null,
     EffectRev.VisibleToPositionAndRadius


### PR DESCRIPTION
This PR hides bot controls when the corresponding bot is dead, and also ensure the facing beam updates smoothly.
