### PR TITLE
feat: add config menu

### DIFF
--- a/interface/config/configMenu.del
+++ b/interface/config/configMenu.del
@@ -1,0 +1,184 @@
+enum ConfigItem {
+  METERS_OPTIMIZED_FOR_OVER_TIME,
+  BUTTON_SPAM_PERIOD,
+  SLOW_MOTION_SPEED,
+  END_SENTINEL
+}
+
+String currentConfigItem: [
+  "HPS/DPS Meter Optimization",
+  "Button Spam Period",
+  "Slow Motion Speed"
+][currentConfigSelection];
+
+playervar ConfigItem currentConfigSelection;
+
+String leftArrow: "◀";
+String rightArrow: "▶";
+
+String[] configMenuButtonLabels: [
+  "", "", "", "", "",
+  "", leftArrow, currentConfigItem, rightArrow, "",
+  "", "", $"{OptimizeMetricsForOverTime}", "", "",
+  "", "", "", "", "",
+  "", "", "", "", ""
+];
+
+Color[] configMenuButtonColors: [
+  null, null, null, null, null,
+  null, Color.White, Color.White, Color.White, null,
+  null, Color.White, Color.White, Color.White, null,
+  null, null, null, null, null,
+  null, null, null, null, null
+];
+
+void ConfigMenu_ThrottleUpDown() {
+  if (ZOf(ThrottleOf()) > 0 && menuYIndex == 2) {
+    menuYIndex = 1;
+    UpdateButtonLabel(MenuState.CONFIG, 1, 1, leftArrow);
+    UpdateButtonLabel(MenuState.CONFIG, 3, 1, rightArrow);
+    UpdateButtonLabel(MenuState.CONFIG, 1, 2, "");
+    UpdateButtonLabel(MenuState.CONFIG, 3, 2, "");
+  } else {
+    menuYIndex = 2;
+    UpdateButtonLabel(MenuState.CONFIG, 1, 1, "");
+    UpdateButtonLabel(MenuState.CONFIG, 3, 1, "");
+    UpdateButtonLabel(MenuState.CONFIG, 1, 2, arrowNarrowSpacing + leftArrow);
+    UpdateButtonLabel(MenuState.CONFIG, 3, 2, rightArrow + arrowNarrowSpacing);
+  }
+}
+
+void ConfigMenu_ThrottleLeftRight() {
+  # Set the current config item
+  if (menuYIndex == 1) {
+    if (XOf(ThrottleOf(EventPlayer())) > 0) {
+      currentConfigSelection = currentConfigSelection - 1;
+      if (currentConfigSelection < 0) {
+        currentConfigSelection = ConfigItem.END_SENTINEL - 1;
+      }
+    } else {
+      currentConfigSelection = currentConfigSelection + 1;
+      if (currentConfigSelection >= ConfigItem.END_SENTINEL) {
+        currentConfigSelection = 0;
+      }
+    }
+    UpdateButtonLabel(MenuState.CONFIG, 2, 1, currentConfigItem);
+    switch (currentConfigSelection) {
+      case ConfigItem.METERS_OPTIMIZED_FOR_OVER_TIME:
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{OptimizeMetricsForOverTime}");
+        break;
+      case ConfigItem.BUTTON_SPAM_PERIOD:
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{BUTTON_SPAM_PERIOD}");
+        break;
+      case ConfigItem.SLOW_MOTION_SPEED:
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{SLOW_MOTION_SPEED}");
+        break;
+    }
+    return;
+  }
+  # Modify the current config item
+  if (XOf(ThrottleOf(EventPlayer())) > 0) {
+    ConfigMenu_Left();
+  } else {
+    // Decrease the value
+    ConfigMenu_Right();
+  }
+}
+
+void ConfigMenu_Left() {
+  switch (currentConfigSelection) {
+    case ConfigItem.METERS_OPTIMIZED_FOR_OVER_TIME:
+      OptimizeMetricsForOverTime = !OptimizeMetricsForOverTime;
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{OptimizeMetricsForOverTime}");
+      break;
+    case ConfigItem.BUTTON_SPAM_PERIOD:
+      if (BUTTON_SPAM_PERIOD <= 0.1) return;
+      BUTTON_SPAM_PERIOD -= IsButtonHeld(EventPlayer(), Button.Ability1) ? 1 : 0.1;
+      BUTTON_SPAM_PERIOD = Max(BUTTON_SPAM_PERIOD, 0.1);
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{BUTTON_SPAM_PERIOD}");
+      tempMenuXIndex = menuXIndex;
+      tempMenuYIndex = menuYIndex;
+      SlowMoAgnosticWait(0.25, WaitBehavior.AbortWhenFalse);
+      while (currentMenuState == MenuState.CONFIG
+        && XOf(ThrottleOf()) > 0
+        && menuXIndex == tempMenuXIndex
+        && menuYIndex == tempMenuYIndex) {
+        if (BUTTON_SPAM_PERIOD <= 0.1) {
+          Abort();
+        }
+        BUTTON_SPAM_PERIOD -= IsButtonHeld(EventPlayer(), Button.Ability1) ? 1 : 0.1;
+        BUTTON_SPAM_PERIOD = Max(BUTTON_SPAM_PERIOD, 0.1);
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{BUTTON_SPAM_PERIOD}");
+        Wait(0.064, WaitBehavior.AbortWhenFalse);
+      }
+      break;
+    case ConfigItem.SLOW_MOTION_SPEED:
+      if (SLOW_MOTION_SPEED <= 10) return;
+      SLOW_MOTION_SPEED -= 5;
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{SLOW_MOTION_SPEED}");
+      tempMenuXIndex = menuXIndex;
+      tempMenuYIndex = menuYIndex;
+      SlowMoAgnosticWait(0.25, WaitBehavior.AbortWhenFalse);
+      while (currentMenuState == MenuState.CONFIG
+        && XOf(ThrottleOf()) > 0
+        && menuXIndex == tempMenuXIndex
+        && menuYIndex == tempMenuYIndex) {
+        if (SLOW_MOTION_SPEED <= 10) {
+          Abort();
+        }
+        SLOW_MOTION_SPEED -= 5;
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{SLOW_MOTION_SPEED}");
+        Wait(IsButtonHeld(EventPlayer(), Button.Ability1) ? 0.064 : 0.1, WaitBehavior.AbortWhenFalse);
+      }
+      break;
+  }
+}
+
+void ConfigMenu_Right() {
+  switch (currentConfigSelection) {
+    case ConfigItem.METERS_OPTIMIZED_FOR_OVER_TIME:
+      OptimizeMetricsForOverTime = !OptimizeMetricsForOverTime;
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{OptimizeMetricsForOverTime}");
+      break;
+    case ConfigItem.BUTTON_SPAM_PERIOD:
+      if (BUTTON_SPAM_PERIOD >= 30) return;
+      BUTTON_SPAM_PERIOD += IsButtonHeld(EventPlayer(), Button.Ability1) ? 1 : 0.1;
+      BUTTON_SPAM_PERIOD = Min(BUTTON_SPAM_PERIOD, 30);
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{BUTTON_SPAM_PERIOD}");
+      tempMenuXIndex = menuXIndex;
+      tempMenuYIndex = menuYIndex;
+      SlowMoAgnosticWait(0.25, WaitBehavior.AbortWhenFalse);
+      while (currentMenuState == MenuState.CONFIG
+        && XOf(ThrottleOf()) < 0
+        && menuXIndex == tempMenuXIndex
+        && menuYIndex == tempMenuYIndex) {
+        if (BUTTON_SPAM_PERIOD >= 30) {
+          Abort();
+        }
+        BUTTON_SPAM_PERIOD += IsButtonHeld(EventPlayer(), Button.Ability1) ? 1 : 0.1;
+        BUTTON_SPAM_PERIOD = Min(BUTTON_SPAM_PERIOD, 30);
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{BUTTON_SPAM_PERIOD}");
+        Wait(0.064, WaitBehavior.AbortWhenFalse);
+      }
+      break;
+    case ConfigItem.SLOW_MOTION_SPEED:
+      if (SLOW_MOTION_SPEED >= 100) return;
+      SLOW_MOTION_SPEED += 5;
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{SLOW_MOTION_SPEED}");
+      tempMenuXIndex = menuXIndex;
+      tempMenuYIndex = menuYIndex;
+      SlowMoAgnosticWait(0.25, WaitBehavior.AbortWhenFalse);
+      while (currentMenuState == MenuState.CONFIG
+        && XOf(ThrottleOf()) < 0
+        && menuXIndex == tempMenuXIndex
+        && menuYIndex == tempMenuYIndex) {
+        if (SLOW_MOTION_SPEED >= 100) {
+          Abort();
+        }
+        SLOW_MOTION_SPEED += 5;
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{SLOW_MOTION_SPEED}");
+        Wait(IsButtonHeld(EventPlayer(), Button.Ability1) ? 0.064 : 0.1, WaitBehavior.AbortWhenFalse);
+      }
+      break;
+  }
+}

--- a/interface/dummyBotsAndReplay/botEditPage_ReplayEdit.del
+++ b/interface/dummyBotsAndReplay/botEditPage_ReplayEdit.del
@@ -18,7 +18,7 @@ String arrowNarrowSpacing: "                 �
 String[] BotEditReplayPageButtonLabels: [
   " ", " ", " ",                           " ", " ",
   " ", " ", "DELAY PLAYBACK OF REPLAY BY", " ", " ",
-  " ", arrowNarrowSpacing + "▼",            "0",                "▲" + arrowNarrowSpacing, " ",
+  " ", arrowNarrowSpacing + "◀",            "0",                "▶" + arrowNarrowSpacing, " ",
   " ", " ",         "FRAMES",              " ", " ",
   " ", " ",      "Reset Delay",            " ", " "
 ];

--- a/interface/dummyBotsAndReplay/botEditPage_ReplayEdit.del
+++ b/interface/dummyBotsAndReplay/botEditPage_ReplayEdit.del
@@ -59,8 +59,8 @@ void HandleBotEditReplayPrimaryFire() {
     UpdateOffsetDisplay();
     Abort();
   }
+  tempMenuXIndex = menuXIndex;
   SlowMoAgnosticWait(0.25, WaitBehavior.AbortWhenFalse);
-  Number tempMenuXIndex = menuXIndex;
   while (currentMenuState == MenuState.EDITING_REPLAY
     && IsButtonHeld(EventPlayer(), Button.PrimaryFire)
     && menuXIndex == tempMenuXIndex) {

--- a/interface/menu.ostw
+++ b/interface/menu.ostw
@@ -9,6 +9,7 @@ import "modifications/modsMenu.ostw";
 import "dummyBotsAndReplay/botsMenu.ostw";
 import "dummyBotsAndReplay/botEditPage.del";
 import "tools/invisibility.del";
+import "config/configMenu.del";
 
 playervar ResetPoint menuActivationPoint;
 
@@ -26,6 +27,7 @@ rule: "[interface/menu.ostw] Set up action grid" -100
   ButtonActionGrid[MenuState.EDITING_DUMMY_BOT] = botEditPageButtonActions;
   ButtonActionGrid[MenuState.EDITING_DUMMY_BOT_BUTTONS] = INTENTIONALLY_EMPTY_ACTION_GRID;
   ButtonActionGrid[MenuState.EDITING_REPLAY] = BotEditReplayActions;
+  ButtonActionGrid[MenuState.CONFIG] = INTENTIONALLY_EMPTY_ACTION_GRID;
 }
 rule: "[interface/menu.ostw] Set up button label grid" -100
 Event.OngoingPlayer
@@ -38,6 +40,7 @@ Event.OngoingPlayer
   ButtonLabelGrid[MenuState.DUMMY_BOTS_AND_REPLAY] = botsReplayMenuButtonLabels;
   ButtonLabelGrid[MenuState.EDITING_DUMMY_BOT] = botEditPageButtonLabels;
   ButtonLabelGrid[MenuState.EDITING_REPLAY] = BotEditReplayPageButtonLabels;
+  ButtonLabelGrid[MenuState.CONFIG] = configMenuButtonLabels;
 }
 rule: "[interface/menu.ostw] Set up color grid" -100
 Event.OngoingPlayer
@@ -50,28 +53,29 @@ Event.OngoingPlayer
   ButtonColorGrid[MenuState.DUMMY_BOTS_AND_REPLAY] = botsReplayMenuButtonColors;
   ButtonColorGrid[MenuState.EDITING_DUMMY_BOT] = botEditPageButtonColors;
   ButtonColorGrid[MenuState.EDITING_REPLAY] = BotEditReplayPageButtonColors;
+  ButtonColorGrid[MenuState.CONFIG] = configMenuButtonColors;
 }
 
 MenuState[] mainMenuButtonActions: [
-  MenuState.CLOSED, MenuState.CLOSED,      MenuState.CLOSED,      MenuState.CLOSED,                MenuState.CLOSED,
-  MenuState.CLOSED, MenuState.INFORMATION, MenuState.CLOSED,      MenuState.MODIFICATIONS,         MenuState.CLOSED,
-  MenuState.CLOSED, MenuState.CLOSED,      MenuState.CLOSED,      MenuState.CLOSED,                MenuState.CLOSED,
-  MenuState.CLOSED, MenuState.TOOLS,       MenuState.CLOSED,      MenuState.DUMMY_BOTS_AND_REPLAY, MenuState.CLOSED,
-  MenuState.CLOSED, MenuState.CLOSED,      MenuState.CLOSED,      MenuState.CLOSED,                MenuState.CLOSED
+  MenuState.CLOSED, MenuState.CLOSED,      MenuState.INFORMATION,                MenuState.CLOSED,                MenuState.CLOSED,
+  MenuState.CLOSED, MenuState.CLOSED,      MenuState.MODIFICATIONS,              MenuState.CLOSED,         MenuState.CLOSED,
+  MenuState.CLOSED, MenuState.CLOSED,      MenuState.TOOLS,                      MenuState.CLOSED,                MenuState.CLOSED,
+  MenuState.CLOSED, MenuState.CLOSED,      MenuState.DUMMY_BOTS_AND_REPLAY,      MenuState.CLOSED,              MenuState.CLOSED,
+  MenuState.CLOSED, MenuState.CLOSED,      MenuState.CONFIG,                     MenuState.CLOSED,                MenuState.CLOSED
 ];
 String[] mainMenuButtonLabels: [
-  "", "",            "",                   "",                  "",
-  "", "Information", "",                   "Modifications",     "",
-  "", "",            "",                   "",                  "",
-  "", "Tools",       "",                   "Dummy Bots/Replay",        "",
-  "", "",            "", "",                  ""
+  "", "",            "Information",        "",     "",
+  "", "",            "Modifications",      "",     "",
+  "", "",            "Tools",              "",     "",
+  "", "",            "Dummy Bots/Replay",  "",     "",
+  "", "",            "Config",             "",     ""
 ];
 Color[] mainMenuButtonColors: [
-  null, null,               null,       null,         null,
-  null, LighterRed,         null,       Color.Green,  null,
-  null, null,               null,       null,         null,
-  null, Color.SkyBlue,      null,       Color.Yellow, null,
-  null, null,               null,       null,         null
+  null, null,        LighterRed,       null,         null,
+  null, null,        Color.Green,      null,         null,
+  null, null,        Color.SkyBlue,    null,         null,
+  null, null,        Color.Yellow,     null,         null,
+  null, null,        Color.Violet,       null,         null
 ];
 
 rule: "[interface/menu.ostw] Global menu setup"
@@ -99,14 +103,22 @@ rule: "[interface/menu.ostw] Global menu setup"
     Spectators:    Spectators.VisibleNever);
   # Additional helper text
   OnScreenText.CreateOnScreenText(
-    VisibleTo:     [MenuState.MAIN_MENU, MenuState.EDITING_DUMMY_BOT_BUTTONS].Contains(LocalPlayer().currentMenuState) ? LocalPlayer() : null,
-    Header:        ["Use WASD to Navigate", $"Press/Hold {InputBindingString(Button.Reload)} for Manual Control"][[MenuState.MAIN_MENU, MenuState.EDITING_DUMMY_BOT_BUTTONS].IndexOf(LocalPlayer().currentMenuState)],
-    PositionX:     0,
-    PositionY:     -1.25,
-    Scale:         2,
-    Color:         Color.White,
-    Reevaluation:  InworldTextRev.VisibleToPositionAndString,
-    Spectators:    Spectators.VisibleNever);
+    VisibleTo:      [MenuState.MAIN_MENU, MenuState.EDITING_DUMMY_BOT_BUTTONS, MenuState.CONFIG].Contains(LocalPlayer().currentMenuState) ? LocalPlayer() : null,
+    Header:         [
+                      "Use WASD to Navigate",
+                      $"Press/Hold {InputBindingString(Button.Reload)} for Manual Control",
+                      $"Hold {InputBindingString(Button.Ability1)} for faster adjustments (if applicable)"
+                    ][[
+                      MenuState.MAIN_MENU,
+                      MenuState.EDITING_DUMMY_BOT_BUTTONS,
+                      MenuState.CONFIG
+                    ].IndexOf(LocalPlayer().currentMenuState)],
+    PositionX:      0,
+    PositionY:      -1.25,
+    Scale:          2,
+    Color:          Color.White,
+    Reevaluation:   InworldTextRev.VisibleToPositionAndString,
+    Spectators:     Spectators.VisibleNever);
   // # DEBUG: grid params
   // printMenuValues();
   # Create grid menu items
@@ -263,8 +275,8 @@ if (IsButtonHeld(EventPlayer(), Button.SecondaryFire))
     return;
   }
   if (ArrayContains([MenuState.INFORMATION, MenuState.MODIFICATIONS, MenuState.TOOLS,
-      MenuState.DUMMY_BOTS_AND_REPLAY], currentMenuState)) {
-    OpenMenuToPage();
+      MenuState.DUMMY_BOTS_AND_REPLAY, MenuState.CONFIG], currentMenuState)) {
+    OpenMenuToPage(EventPlayer(), MenuState.MAIN_MENU);
     return;
   }
   if (currentMenuState == MenuState.CONFIRMING_END_GAME) {
@@ -292,6 +304,10 @@ if (AbsoluteValue(XOf(ThrottleOf(EventPlayer()))) > 0.5)
     # The left-right function does nothing in this menu page
     Abort();
   }
+  if (currentMenuState == MenuState.CONFIG) {
+    ConfigMenu_ThrottleLeftRight();
+    Abort();
+  }
   if (XOf(ThrottleOf(EventPlayer())) > 0) {
     findLeft();
   } else {
@@ -307,6 +323,10 @@ if (AbsoluteValue(ZOf(ThrottleOf())) > 0.5) {
     BotButtonEdit_HandleUpDown();
     return;
   }
+  if (currentMenuState == MenuState.CONFIG) {
+    ConfigMenu_ThrottleUpDown();
+    return;
+  }
   if (ZOf(ThrottleOf()) > 0) {
     findUp();
   } else {
@@ -314,7 +334,7 @@ if (AbsoluteValue(ZOf(ThrottleOf())) > 0.5) {
   }
 }
 
-MenuState[] NO_AUTO_SET_INDICES_MENUS: [MenuState.CONFIRMING_END_GAME, MenuState.EDITING_DUMMY_BOT_BUTTONS];
+MenuState[] NO_AUTO_SET_INDICES_MENUS: [MenuState.CONFIRMING_END_GAME, MenuState.EDITING_DUMMY_BOT_BUTTONS, MenuState.CONFIG];
 rule: "[interface/menu.ostw] When menu state changes, find new first selection" -1
 Event.OngoingPlayer
 if (currentMenuState != MenuState.CLOSED)
@@ -322,6 +342,10 @@ if (currentMenuState != MenuState.CLOSED)
   Wait(0.064, WaitBehavior.AbortWhenFalse);
   // # DEBUG
   // LogToInspector($"Current action grid element count: {CountOf(currentActionGrid())}");
+  if (currentMenuState == MenuState.CONFIG) {
+    menuXIndex = 2;
+    menuYIndex = 1;
+  }
   if (currentActionGrid() != 0 && !ArrayContains(NO_AUTO_SET_INDICES_MENUS, currentMenuState)) {
     AutoSetMenuIndices();
   }

--- a/interface/menuDefinitions.ostw
+++ b/interface/menuDefinitions.ostw
@@ -24,7 +24,9 @@ playervar Color[][] ButtonColorGrid; // Player variable so that the display may 
 playervar MenuState currentMenuState = MenuState.CLOSED;
 // playervar Cursor | Number cursor = -1;
 playervar Number menuXIndex; // Positive to the right
+playervar Number tempMenuXIndex;
 playervar Number menuYIndex; // Positive downwards
+playervar Number tempMenuYIndex;
 playervar Boolean hideMenuOpenTooltip = WorkshopSettingToggle(MenuSettingsCategory, "Hide Before-First-Use Menu Open/Close Tooltip", true);
 
 // Index is rowIndex * numCols + colIndex

--- a/interface/menuDefinitions.ostw
+++ b/interface/menuDefinitions.ostw
@@ -13,7 +13,8 @@ enum MenuState
   DUMMY_BOTS_AND_REPLAY,
   EDITING_DUMMY_BOT,
   EDITING_REPLAY,
-  EDITING_DUMMY_BOT_BUTTONS
+  EDITING_DUMMY_BOT_BUTTONS,
+  CONFIG
 }
 
 globalvar Any[][] ButtonActionGrid;
@@ -79,7 +80,7 @@ Any menuButton(in Number colIndex, in Number rowIndex):
     PositionY: rowIndexToY(rowIndex),
     Scale: 2,
     Reevaluation: InworldTextRev.VisibleToPositionStringAndColor,
-    Color: isSelectingGridIndex(LocalPlayer(), colIndex, rowIndex) && ButtonActionGrid[LocalPlayer().currentMenuState][currentGridIndex(LocalPlayer())]
+    Color: isSelectingGridIndex(LocalPlayer(), colIndex, rowIndex)
       ? selectedColor
       : currentColorGrid()[gridIndex(colIndex, rowIndex)],
     Spectators: Spectators.VisibleNever

--- a/interface/modifications/modsMenu.ostw
+++ b/interface/modifications/modsMenu.ostw
@@ -152,7 +152,7 @@ if (IsModificationActive(Modification.SLOW_MOTION))
   UpdateButtonAppearance(MenuState.MODIFICATIONS, 2, 2, "Slow Motion [OFF]", Color.Gray);
 }
 
-globalvar Number SLOW_MOTION_SPEED = WorkshopSettingInteger(ModSettingsCategory, "Slow Motion Speed", 25, 1, 100);
+globalvar Number SLOW_MOTION_SPEED = WorkshopSettingInteger(ModSettingsCategory, "Slow Motion Speed", 25, 10, 100);
 
 rule: "[interface/modifications/modsMenu.ostw] Handle slow motion"
 if (IsModificationActive(Modification.SLOW_MOTION))


### PR DESCRIPTION
This PR adds a config menu which allows on-the-fly adjustment of commonly-adjusted values without restarting the lobby.

Commits:
- **feat: add config menu**
- **feat: replace arrows on bot replay edit page**
- **refactor: move temp menu index storage to centralized location**
- **fix: properly limit slow motion speed**
