### PR TITLE
fix: prevent punching bags from waking early when slept

### DIFF
--- a/interface/modifications/modsMenu.ostw
+++ b/interface/modifications/modsMenu.ostw
@@ -178,7 +178,7 @@ Event.OngoingPlayer
 if (NormalizedHealth() < 1)
 {
   Wait(AllSupportHeroes().Contains(EffectiveHero()) ? 2.45 : MaxHealthOfType(EventPlayer(), HealthType.Shields) > 0 ? 2.95 : 4.95, WaitBehavior.AbortWhenFalse);
-  LoopIf(!IsModificationActive(Modification.DISABLE_SUPPORT_PASSIVE) && !isPunchingBag);
+  LoopIf(HasStatus(EventPlayer(), Status.Asleep) && !IsModificationActive(Modification.DISABLE_SUPPORT_PASSIVE) && !isPunchingBag);
   if (Health() <= 0.001) SetPlayerHealth(EventPlayer(), 0.002);
   Damage(EventPlayer(), null, 0.001);
   Heal(EventPlayer(), null, 0.001);


### PR DESCRIPTION
This PR prevents the damage inflicted to prevent the self-heal passive from triggering on punching bags who are asleep
