### PR TITLE
fix: various replay issues

### DIFF
--- a/interface/config/configMenu.del
+++ b/interface/config/configMenu.del
@@ -4,6 +4,7 @@ enum ConfigItem {
   SLOW_MOTION_SPEED,
   INTERACT_DESTROYS_DEPLOYABLES_IN_REPLAY,
   RECORD_IN_SLOW_MOTION,
+  LOOP_REPLAY,
   // PUNCHING_BAG_HEALTH_PERCENTAGE,
   // SHOULD_PUNCHIING_BAG_NAME_CHANGE,
   END_SENTINEL
@@ -14,7 +15,8 @@ String currentConfigItem: [
   "Button Spam Period",
   "Slow Motion Speed",
   "Interact Destroys Deployables In Replay",
-  "Auto Enable Slow-Mo During Recording"
+  "Auto Enable Slow-Mo During Recording",
+  "Loop Replay Playback"
 ][currentConfigSelection];
 
 // globalvar Boolean SHOULD_PUNCHIING_BAG_NAME_CHANGE = WorkshopSettingToggle(BotAndReplaySettingsCategory, "Should Punching Bag Name Change", true);
@@ -87,6 +89,9 @@ void ConfigMenu_ThrottleLeftRight() {
       case ConfigItem.RECORD_IN_SLOW_MOTION:
         UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{RECORD_IN_SLOW_MOTION}");
         break;
+      case ConfigItem.LOOP_REPLAY:
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{SHOULD_LOOP_CLIP}");
+        break;
       // case ConfigItem.PUNCHING_BAG_HEALTH_PERCENTAGE:
       //   UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{punchingBagTargetHealthProportion * 100}");
       //   break;
@@ -156,6 +161,10 @@ void ConfigMenu_Left() {
       RECORD_IN_SLOW_MOTION = !RECORD_IN_SLOW_MOTION;
       UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{RECORD_IN_SLOW_MOTION}");
       break;
+    case ConfigItem.LOOP_REPLAY:
+      SHOULD_LOOP_CLIP = !SHOULD_LOOP_CLIP;
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{SHOULD_LOOP_CLIP}");
+      break;
   }
 }
 
@@ -212,6 +221,10 @@ void ConfigMenu_Right() {
     case ConfigItem.RECORD_IN_SLOW_MOTION:
       RECORD_IN_SLOW_MOTION = !RECORD_IN_SLOW_MOTION;
       UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{RECORD_IN_SLOW_MOTION}");
+      break;
+    case ConfigItem.LOOP_REPLAY:
+      SHOULD_LOOP_CLIP = !SHOULD_LOOP_CLIP;
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{SHOULD_LOOP_CLIP}");
       break;
   }
 }

--- a/interface/config/configMenu.del
+++ b/interface/config/configMenu.del
@@ -3,6 +3,7 @@ enum ConfigItem {
   BUTTON_SPAM_PERIOD,
   SLOW_MOTION_SPEED,
   INTERACT_DESTROYS_DEPLOYABLES_IN_REPLAY,
+  RECORD_IN_SLOW_MOTION,
   // PUNCHING_BAG_HEALTH_PERCENTAGE,
   // SHOULD_PUNCHIING_BAG_NAME_CHANGE,
   END_SENTINEL
@@ -12,7 +13,8 @@ String currentConfigItem: [
   "HPS/DPS Meter Optimization",
   "Button Spam Period",
   "Slow Motion Speed",
-  "Interact Destroys Deployables In Replay"
+  "Interact Destroys Deployables In Replay",
+  "Auto Enable Slow-Mo During Recording"
 ][currentConfigSelection];
 
 // globalvar Boolean SHOULD_PUNCHIING_BAG_NAME_CHANGE = WorkshopSettingToggle(BotAndReplaySettingsCategory, "Should Punching Bag Name Change", true);
@@ -82,6 +84,9 @@ void ConfigMenu_ThrottleLeftRight() {
       case ConfigItem.INTERACT_DESTROYS_DEPLOYABLES_IN_REPLAY:
         UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{interactDestroysDeployableCompensation}");
         break;
+      case ConfigItem.RECORD_IN_SLOW_MOTION:
+        UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{RECORD_IN_SLOW_MOTION}");
+        break;
       // case ConfigItem.PUNCHING_BAG_HEALTH_PERCENTAGE:
       //   UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{punchingBagTargetHealthProportion * 100}");
       //   break;
@@ -147,6 +152,10 @@ void ConfigMenu_Left() {
       interactDestroysDeployableCompensation = !interactDestroysDeployableCompensation;
       UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{interactDestroysDeployableCompensation}");
       break;
+    case ConfigItem.RECORD_IN_SLOW_MOTION:
+      RECORD_IN_SLOW_MOTION = !RECORD_IN_SLOW_MOTION;
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{RECORD_IN_SLOW_MOTION}");
+      break;
   }
 }
 
@@ -199,6 +208,10 @@ void ConfigMenu_Right() {
     case ConfigItem.INTERACT_DESTROYS_DEPLOYABLES_IN_REPLAY:
       interactDestroysDeployableCompensation = !interactDestroysDeployableCompensation;
       UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{interactDestroysDeployableCompensation}");
+      break;
+    case ConfigItem.RECORD_IN_SLOW_MOTION:
+      RECORD_IN_SLOW_MOTION = !RECORD_IN_SLOW_MOTION;
+      UpdateButtonLabel(MenuState.CONFIG, 2, 2, $"{RECORD_IN_SLOW_MOTION}");
       break;
   }
 }

--- a/interface/dummyBotsAndReplay/botEditPage.del
+++ b/interface/dummyBotsAndReplay/botEditPage.del
@@ -219,7 +219,7 @@ void ChangeBotHero() {
   ResetHeroAvailability(EventPlayer());
   WaitUntil(HasSpawned(), 1000000);
   DestroyDummyBot(TeamOf(selectedBot), SlotOf(selectedBot));
-  MinWait();
+  Wait(0.064);
   selectedBot = CreateDummyBot(HeroOf(), tempTeamStorage, -1, tempCurrentPosition.location, tempCurrentPosition.facing);
   ForcePlayerHero(EventPlayer(), tempHeroStorage);
   MinWait();

--- a/interface/dummyBotsAndReplay/botPlacementModule.ostw
+++ b/interface/dummyBotsAndReplay/botPlacementModule.ostw
@@ -12,7 +12,7 @@ void Menu_CreateBot() {
   );
 }
 
-globalvar Number punchingBagTargetHealthProportion = WorkshopSettingReal(GeneralSettingsCategory, "Punching Bag Target Health Proportion", 0.8, 0, 1, 0.01);
+globalvar Number punchingBagTargetHealthProportion = WorkshopSettingReal(BotAndReplaySettingsCategory, "Punching Bag Target Health Proportion", 0.8, 0, 1, 0.01);
 rule: "[interface/dummyBotsAndReplay/botPlacementModule.ostw] Maintain punching bag health"
 Event.OngoingPlayer
 if (isPunchingBag)

--- a/interface/dummyBotsAndReplay/replay/replay.del
+++ b/interface/dummyBotsAndReplay/replay/replay.del
@@ -42,12 +42,6 @@ if (EventPlayer().replayState == ReplayState.PLAYING)
   replayStateAction = ReplayStateAction.STOP_PLAYBACK;
 }
 
-rule: "[interface/dummyBotsAndReplay/replay/replay.del] Update longest recording length when player leaves"
-Event.OnPlayerLeave
-{
-  UpdateLongestRecordingLength();
-}
-
 enum RecordingAction {
   NONE,
   PLAY,

--- a/interface/dummyBotsAndReplay/replay/replayDefs.del
+++ b/interface/dummyBotsAndReplay/replay/replayDefs.del
@@ -48,6 +48,7 @@ single struct SnapshotState {
 
 globalvar Boolean SHOULD_LOOP_CLIP = WorkshopSettingToggle(BotAndReplaySettingsCategory, "Loop Replay Playback", true);
 globalvar Number longestRecordingLength = 0;
+globalvar Boolean RECORD_IN_SLOW_MOTION = WorkshopSettingToggle(BotAndReplaySettingsCategory, "Automatically Enable Slow Motion During Recording", true);
 
 playervar ResetPoint replayResetPoint;
 playervar Number frame;

--- a/interface/dummyBotsAndReplay/replay/replayDefs.del
+++ b/interface/dummyBotsAndReplay/replay/replayDefs.del
@@ -47,7 +47,6 @@ single struct SnapshotState {
 }
 
 globalvar Boolean SHOULD_LOOP_CLIP = WorkshopSettingToggle(BotAndReplaySettingsCategory, "Loop Replay Playback", true);
-globalvar Number longestRecordingLength = 0;
 globalvar Boolean RECORD_IN_SLOW_MOTION = WorkshopSettingToggle(BotAndReplaySettingsCategory, "Automatically Enable Slow Motion During Recording", true);
 
 playervar ResetPoint replayResetPoint;
@@ -95,7 +94,6 @@ void DeleteRecording() playervar "[SUB | interface/dummyBotsAndReplay/replay/rep
   recording = [[]];
   replayResetPoint.location = null;
   recordingHero = null;
-  UpdateLongestRecordingLength();
   DumpLogBuffer($"DEL {TeamOf()} {SlotOf()}");
 }
 
@@ -109,12 +107,6 @@ void TransferRecording(in Player from, in Player to) {
   from.totalFrames = 0;
   from.playbackOffset = 0;
   from.recordingHero = null;
-  UpdateLongestRecordingLength();
-}
-
-void UpdateLongestRecordingLength() "[SUB | interface/dummyBotsAndReplay/replay/replayDefs.del] Update Longest Recording Length" {
-  longestRecordingLength = AllPlayers().Filter(p => IsControllable(p) && hasRecordedClip(p)).Sort(p => p.totalFrames + p.playbackOffset).Last;
-  longestRecordingLength = (<Player>longestRecordingLength).totalFrames + (<Player>longestRecordingLength).playbackOffset;
 }
 
 rule: "[interface/dummyBotsAndReplay/replay/replayDefs.del] When bot is in recording state, loop every frame and record inputs"

--- a/interface/dummyBotsAndReplay/replay/replayDefs.del
+++ b/interface/dummyBotsAndReplay/replay/replayDefs.del
@@ -69,6 +69,7 @@ Boolean IsBotReplaying(Player p = EventPlayer()): [
     ReplayState.PLAYING,
     ReplayState.REACHED_END_OF_REPLAY
   ].Contains(p.replayState);
+Player[] AllBotsReplaying(): AllPlayers().Filter(p => IsBotReplaying(p));
 Number MAX_ARRAY_SIZE: 1000;
 Number TICK_LENGTH: 0.016;
 Boolean hasRecordedClip(Player p = EventPlayer()): p.totalFrames > 0;

--- a/interface/dummyBotsAndReplay/replay/replayStateMachine.del
+++ b/interface/dummyBotsAndReplay/replay/replayStateMachine.del
@@ -289,7 +289,7 @@ if (replayState == ReplayState.PREPARING_TO_RECORD)
 
   WaitUntil(shouldAbortRecordingCountdown(), 0.8);
   if (shouldAbortRecordingCountdown()) {
-    replayStateAction = ReplayStateAction.STOP_PLAYBACK;
+    replayStateAction = ReplayStateAction.STOP_RECORDING;
     SmallMessage(EventPlayer(), "  Recording aborted");
     Abort();
   }
@@ -304,7 +304,7 @@ if (replayState == ReplayState.PREPARING_TO_RECORD)
   );
   SlowMoAgnosticWaitUntil(shouldAbortRecordingCountdown(), 0.8);
   if (shouldAbortRecordingCountdown()) {
-    replayStateAction = ReplayStateAction.STOP_PLAYBACK;
+    replayStateAction = ReplayStateAction.STOP_RECORDING;
     SmallMessage(EventPlayer(), "  Recording aborted");
     Abort();
   }
@@ -313,7 +313,7 @@ if (replayState == ReplayState.PREPARING_TO_RECORD)
   recordingCountdownText.textColor = Color.Yellow;
   SlowMoAgnosticWaitUntil(shouldAbortRecordingCountdown(), 0.8);
   if (shouldAbortRecordingCountdown()) {
-    replayStateAction = ReplayStateAction.STOP_PLAYBACK;
+    replayStateAction = ReplayStateAction.STOP_RECORDING;
     SmallMessage(EventPlayer(), "  Recording aborted");
     Abort();
   }
@@ -322,7 +322,7 @@ if (replayState == ReplayState.PREPARING_TO_RECORD)
   recordingCountdownText.textColor = Color.Green;
   SlowMoAgnosticWaitUntil(shouldAbortRecordingCountdown(), 0.8);
   if (shouldAbortRecordingCountdown()) {
-    replayStateAction = ReplayStateAction.STOP_PLAYBACK;
+    replayStateAction = ReplayStateAction.STOP_RECORDING;
     SmallMessage(EventPlayer(), "  Recording aborted");
     Abort();
   }

--- a/interface/dummyBotsAndReplay/replay/replayStateMachine.del
+++ b/interface/dummyBotsAndReplay/replay/replayStateMachine.del
@@ -211,6 +211,8 @@ void OnRecordingStop() {
   # Add one more dummy frame to the end to ensure OOB doesn't happen
   SafeAppendToBigArray(selectedBot.recording, <DeltaFrame>[DeltaFrame.New([], frame)]);
   selectedBot.totalFrames = frame;
+  # If bots are prompted to start replaying when
+  if (allBotsReplayDuringRecording) AllBotsReplaying().replayStateAction = ReplayStateAction.STOP_PLAYBACK;
   SmallMessage(EventPlayer(), "  Recording complete");
 }
 

--- a/interface/dummyBotsAndReplay/replay/replayStateMachine.del
+++ b/interface/dummyBotsAndReplay/replay/replayStateMachine.del
@@ -92,6 +92,9 @@ void HandleReplayStateAction_PreparingToRecord()
       OnRecordingStart();
       break;
     case ReplayStateAction.STOP_RECORDING:
+      if (RECORD_IN_SLOW_MOTION) {
+        activeModifications[Modification.SLOW_MOTION] = false;
+      }
       DestroyInWorldText(recordingCountdownText.textID);
       RestoreBot();
       replayState = ReplayState.NONE;
@@ -103,6 +106,9 @@ void HandleReplayStateAction_Recording()
 {
   switch (replayStateAction) {
     case ReplayStateAction.STOP_RECORDING:
+      if (RECORD_IN_SLOW_MOTION) {
+        activeModifications[Modification.SLOW_MOTION] = false;
+      }
       StartEditingBots();
       CloseMenu(EventPlayer());
       RestoreBot();
@@ -170,6 +176,7 @@ void HandleReplayStateAction_ReachedEndOfReplay()
 */
 
 void OnRecordingStart() {
+  if (RECORD_IN_SLOW_MOTION) activeModifications[Modification.SLOW_MOTION] = true;
   frame = 0;
   selectedBot.changeBuffer = [
     InputChange<Any>.New(InputType.THROTTLE, ThrottleOf(EventPlayer())),
@@ -290,6 +297,9 @@ if (replayState == ReplayState.PREPARING_TO_RECORD)
     AllBotsWithRecordings().replayStateAction = ReplayStateAction.PREPARE_FOR_PLAYBACK;
   }
   recordingCountdownText = { timerValue: 3, textColor: LighterRed, textID: null };
+  if (RECORD_IN_SLOW_MOTION) {
+    activeModifications[Modification.SLOW_MOTION] = true;
+  }
 
   WaitUntil(shouldAbortRecordingCountdown(), 0.8);
   if (shouldAbortRecordingCountdown()) {

--- a/interface/dummyBotsAndReplay/replay/replayStateMachine.del
+++ b/interface/dummyBotsAndReplay/replay/replayStateMachine.del
@@ -92,6 +92,7 @@ void HandleReplayStateAction_PreparingToRecord()
       OnRecordingStart();
       break;
     case ReplayStateAction.STOP_RECORDING:
+      DestroyInWorldText(recordingCountdownText.textID);
       RestoreBot();
       replayState = ReplayState.NONE;
       break;

--- a/interface/dummyBotsAndReplay/replay/replayStateMachine.del
+++ b/interface/dummyBotsAndReplay/replay/replayStateMachine.del
@@ -381,8 +381,7 @@ if (replayState == ReplayState.REACHED_END_OF_REPLAY)
       .IsTrueForAll(p => [ReplayState.REACHED_END_OF_REPLAY, ReplayState.NONE].Contains(p.replayState)),
     1000000);
 
-  AbortIf(replayState != ReplayState.REACHED_END_OF_REPLAY);
-  if (SHOULD_LOOP_CLIP) {
+  if (SHOULD_LOOP_CLIP && replayState == ReplayState.REACHED_END_OF_REPLAY) {
     replayStateAction = ReplayStateAction.START_PLAYBACK;
   } else {
     replayStateAction = ReplayStateAction.STOP_PLAYBACK;

--- a/interface/dummyBotsAndReplay/replay/replayStateMachine.del
+++ b/interface/dummyBotsAndReplay/replay/replayStateMachine.del
@@ -29,7 +29,8 @@ rule: "[interface/dummyBotsAndReplay/replay/replayStateMachine.del] Process repl
 Event.OngoingPlayer
 if (replayStateAction != ReplayStateAction.NONE)
 {
-  // DumpLogBuffer("Replay State Handler for " + EventPlayer() + ": [State " + replayState + "] [Action: " + replayStateAction + "]");
+  # DEBUG
+  DumpLogBuffer("Replay State Handler for " + EventPlayer() + ": [State " + replayState + "] [Action: " + replayStateAction + "]");
   switch (replayState) {
     case ReplayState.NONE:
       HandleReplayStateAction_Normal();
@@ -53,8 +54,8 @@ if (replayStateAction != ReplayStateAction.NONE)
       HandleReplayStateAction_ReachedEndOfReplay();
       break;
   }
-  // # DEBUG
-  // DumpLogBuffer("Exiting Replay State Handler for " + EventPlayer() + ": [State " + replayState + "] [Action: " + replayStateAction + "]");
+  # DEBUG
+  DumpLogBuffer("Exiting Replay State Handler for " + EventPlayer() + ": [State " + replayState + "] [Action: " + replayStateAction + "]");
   replayStateAction = ReplayStateAction.NONE;
   MinWait();
   LoopIfConditionIsTrue();

--- a/interface/dummyBotsAndReplay/replay/replayStateMachine.del
+++ b/interface/dummyBotsAndReplay/replay/replayStateMachine.del
@@ -103,6 +103,8 @@ void HandleReplayStateAction_Recording()
 {
   switch (replayStateAction) {
     case ReplayStateAction.STOP_RECORDING:
+      StartEditingBots();
+      CloseMenu(EventPlayer());
       RestoreBot();
       replayState = ReplayState.NONE;
       OnRecordingStop();

--- a/interface/dummyBotsAndReplay/replay/replayStateMachine.del
+++ b/interface/dummyBotsAndReplay/replay/replayStateMachine.del
@@ -374,6 +374,11 @@ rule: "[interface/dummyBotsAndReplay/replay/replayStateMachine.del] Auto-transit
 Event.OngoingPlayer
 if (replayState == ReplayState.REACHED_END_OF_REPLAY)
 {
+  # If recording, we should never loop, since recordings
+  if (AllPlayers().IsTrueForAny(p => [ReplayState.PREPARING_TO_RECORD, ReplayState.RECORDING].Contains(p.replayState))) {
+    replayStateAction = ReplayStateAction.STOP_PLAYBACK;
+    return;
+  }
   WaitUntil(
     AllPlayers()
       .Filter(p => IsControllable(p)

--- a/interface/information/damageNumbers.ostw
+++ b/interface/information/damageNumbers.ostw
@@ -3,17 +3,17 @@ import "../../lib/utils/Colors.del";
 
 Number LINGER_TIME_IN_SECONDS: 3;
 
-playervar Any cumulativeDamageDisplayTextID! = -1;
-playervar Any lastDamageDisplayTextID! = -1;
-playervar Number cumulativeDamage!;
-playervar Number lastDamageInstanceAmount!;
-playervar Vector lastDamageInstancePosition!;
+playervar Any totalDamageDisplayTextID = -1;
+playervar Any lastDamageDisplayTextID = -1;
+playervar Number totalDamage;
+playervar Number lastDamageInstanceAmount;
+playervar Vector lastDamageInstancePosition;
 
-playervar Any cumulativeHealingDisplayTextID! = -1;
-playervar Any lastHealingDisplayTextID! = -1;
-playervar Number cumulativeHealing!;
-playervar Number lastHealInstanceAmount!;
-playervar Vector lastHealInstancePosition!;
+playervar Any totalHealingDisplayTextID = -1;
+playervar Any lastHealingDisplayTextID = -1;
+playervar Number totalHealing;
+playervar Number lastHealInstanceAmount;
+playervar Vector lastHealInstancePosition;
 
 String OFFSET: "    ";
 
@@ -36,12 +36,12 @@ if (EventDamage() > 0)
   lastDamageInstanceAmount = EventDamage();
   lastDamageInstancePosition = PositionOf();
   # If we don't have any active cumulative damage number, reset and create it
-  if (cumulativeDamageDisplayTextID == -1) {
-    cumulativeDamage = EventDamage();
+  if (totalDamageDisplayTextID == -1) {
+    totalDamage = EventDamage();
 
-    cumulativeDamageDisplayTextID = CreateInWorldText(
+    totalDamageDisplayTextID = CreateInWorldText(
       VisibleTo: AllPlayers().FilteredArray((player) => player.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_NUMBERS)),
-      Header: <"-<0><1>", cumulativeDamage, (cumulativeHealingDisplayTextID != -1 ? OFFSET : "")>,
+      Header: <"-<0><1>", totalDamage, (totalHealingDisplayTextID != -1 ? OFFSET : "")>,
       Position: UpdateEveryFrame(PositionOf()) + Up() * cumulativeInstanceYOffset,
       Scale: 4,
       Clipping: Clipping.DoNotClip,
@@ -50,7 +50,7 @@ if (EventDamage() > 0)
     );
     lastDamageDisplayTextID = CreateInWorldText(
       VisibleTo: AllPlayers().FilteredArray((player) => player.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_NUMBERS)),
-      Header: <"-<0><1>", lastDamageInstanceAmount, (cumulativeHealingDisplayTextID != -1 ? OFFSET : "")>,
+      Header: <"-<0><1>", lastDamageInstanceAmount, (totalHealingDisplayTextID != -1 ? OFFSET : "")>,
       Position: lastDamageInstancePosition + Up() * lastInstanceYOffset,
       Scale: 2,
       Clipping: Clipping.DoNotClip,
@@ -58,12 +58,12 @@ if (EventDamage() > 0)
       TextColor: LighterRed
     );
   } else {
-    cumulativeDamage += EventDamage();
+    totalDamage += EventDamage();
   }
   Wait(LINGER_TIME_IN_SECONDS, WaitBehavior.RestartWhenTrue);
-  DestroyInWorldText(cumulativeDamageDisplayTextID);
+  DestroyInWorldText(totalDamageDisplayTextID);
   DestroyInWorldText(lastDamageDisplayTextID);
-  cumulativeDamageDisplayTextID = -1;
+  totalDamageDisplayTextID = -1;
   lastDamageDisplayTextID = -1;
 }
 
@@ -74,12 +74,12 @@ if (EventHealing() > 0)
   lastHealInstanceAmount = EventHealing();
   lastHealInstancePosition = PositionOf();
   # If we don't have any active damage number, reset and create it
-  if (cumulativeHealingDisplayTextID == -1) {
-    cumulativeHealing = EventHealing();
+  if (totalHealingDisplayTextID == -1) {
+    totalHealing = EventHealing();
 
-    cumulativeHealingDisplayTextID = CreateInWorldText(
+    totalHealingDisplayTextID = CreateInWorldText(
       VisibleTo: AllPlayers().FilteredArray((player) => player.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_NUMBERS)),
-      Header: <"<1>+<0>", cumulativeHealing, (cumulativeDamageDisplayTextID != -1 ? OFFSET : "")>,
+      Header: <"<1>+<0>", totalHealing, (totalDamageDisplayTextID != -1 ? OFFSET : "")>,
       Position: UpdateEveryFrame(PositionOf()) + Up() * cumulativeInstanceYOffset,
       Scale: 4,
       Clipping: Clipping.DoNotClip,
@@ -88,7 +88,7 @@ if (EventHealing() > 0)
     );
     lastHealingDisplayTextID = CreateInWorldText(
       VisibleTo: AllPlayers().FilteredArray((player) => player.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_NUMBERS)),
-      Header: <"<1>+<0>", lastHealInstanceAmount, (cumulativeDamageDisplayTextID != -1 ? OFFSET : "")>,
+      Header: <"<1>+<0>", lastHealInstanceAmount, (totalDamageDisplayTextID != -1 ? OFFSET : "")>,
       Position: lastHealInstancePosition + Up() * lastInstanceYOffset,
       Scale: 1.5,
       Clipping: Clipping.DoNotClip,
@@ -96,11 +96,11 @@ if (EventHealing() > 0)
       TextColor: Color.Yellow
     );
   } else {
-    cumulativeHealing += EventHealing();
+    totalHealing += EventHealing();
   }
   Wait(LINGER_TIME_IN_SECONDS, WaitBehavior.RestartWhenTrue);
-  DestroyInWorldText(cumulativeHealingDisplayTextID);
+  DestroyInWorldText(totalHealingDisplayTextID);
   DestroyInWorldText(lastHealingDisplayTextID);
-  cumulativeHealingDisplayTextID = -1;
+  totalHealingDisplayTextID = -1;
   lastHealingDisplayTextID = -1;
 }

--- a/interface/information/metricsReadouts.ostw
+++ b/interface/information/metricsReadouts.ostw
@@ -8,9 +8,9 @@ if (activeInfoDisplays.Contains(InfoAction.HEALING_DEALT_PER_SECOND_DISPLAY))
 {
   infoDisplayEntities[InfoAction.HEALING_DEALT_PER_SECOND_DISPLAY] = CreateHudText(
     VisibleTo: EventPlayer().currentMenuState == MenuState.CLOSED ? EventPlayer() : null,
-    Header: <"HPS Dealt: <0>", UpdateEveryFrame((healDealtInPeriod) / durationToAverageOver)>,
-    Subheader: <"Self: <0>", Max(0, UpdateEveryFrame((healDealtInPeriod - healDealtInPeriodNonSelf) / durationToAverageOver))>,
-    Text: <"Other: <0><1>", UpdateEveryFrame((healDealtInPeriodNonSelf) / durationToAverageOver), MANY_SPACES>,
+    Header: <"HPS Dealt: <0>", UpdateEveryFrame((healDealtInPeriod) / DURATION_TO_AVERAGE_OVER)>,
+    Subheader: <"Self: <0>", Max(0, UpdateEveryFrame((healDealtInPeriod - healDealtInPeriodNonSelf) / DURATION_TO_AVERAGE_OVER))>,
+    Text: <"Other: <0><1>", UpdateEveryFrame((healDealtInPeriodNonSelf) / DURATION_TO_AVERAGE_OVER), MANY_SPACES>,
     SortOrder: activeInfoDisplays.IndexOf(InfoAction.HEALING_DEALT_PER_SECOND_DISPLAY)
   );
   UpdateButtonAppearance(MenuState.INFORMATION, 1, 3, "Hide HPS Dealt", Color.Gray);
@@ -25,9 +25,9 @@ if (activeInfoDisplays.Contains(InfoAction.HEALING_RECEIVED_PER_SECOND_DISPLAY))
 {
   infoDisplayEntities[InfoAction.HEALING_RECEIVED_PER_SECOND_DISPLAY] = CreateHudText(
     VisibleTo: EventPlayer().currentMenuState == MenuState.CLOSED ? EventPlayer() : null,
-    Header: <"HPS Received: <0>", UpdateEveryFrame((healReceivedInPeriod) / durationToAverageOver)>,
-    Subheader: <"Self: <0>", Max(0, UpdateEveryFrame((healReceivedInPeriod - healReceivedInPeriodNonSelf) / durationToAverageOver))>,
-    Text: <"Other: <0><1>", UpdateEveryFrame((healReceivedInPeriodNonSelf) / durationToAverageOver), MANY_SPACES>,
+    Header: <"HPS Received: <0>", UpdateEveryFrame((healReceivedInPeriod) / DURATION_TO_AVERAGE_OVER)>,
+    Subheader: <"Self: <0>", Max(0, UpdateEveryFrame((healReceivedInPeriod - healReceivedInPeriodNonSelf) / DURATION_TO_AVERAGE_OVER))>,
+    Text: <"Other: <0><1>", UpdateEveryFrame((healReceivedInPeriodNonSelf) / DURATION_TO_AVERAGE_OVER), MANY_SPACES>,
     SortOrder: activeInfoDisplays.IndexOf(InfoAction.HEALING_RECEIVED_PER_SECOND_DISPLAY)
   );
   UpdateButtonAppearance(MenuState.INFORMATION, 1, 4, "Hide HPS Received", Color.Gray);
@@ -42,9 +42,9 @@ if (activeInfoDisplays.Contains(InfoAction.DAMAGE_DEALT_PER_SECOND_DISPLAY))
 {
   infoDisplayEntities[InfoAction.DAMAGE_DEALT_PER_SECOND_DISPLAY] = CreateHudText(
     VisibleTo: EventPlayer().currentMenuState == MenuState.CLOSED ? EventPlayer() : null,
-    Header: <"DPS Dealt: <0>", UpdateEveryFrame((damageDealtInPeriod) / durationToAverageOver)>,
-    Subheader: <"Self: <0>", Max(0, UpdateEveryFrame((damageDealtInPeriod - damageDealtInPeriodNonSelf) / durationToAverageOver))>,
-    Text: <"Other: <0><1>", UpdateEveryFrame((damageDealtInPeriodNonSelf) / durationToAverageOver), MANY_SPACES>,
+    Header: <"DPS Dealt: <0>", UpdateEveryFrame((damageDealtInPeriod) / DURATION_TO_AVERAGE_OVER)>,
+    Subheader: <"Self: <0>", Max(0, UpdateEveryFrame((damageDealtInPeriod - damageDealtInPeriodNonSelf) / DURATION_TO_AVERAGE_OVER))>,
+    Text: <"Other: <0><1>", UpdateEveryFrame((damageDealtInPeriodNonSelf) / DURATION_TO_AVERAGE_OVER), MANY_SPACES>,
     SortOrder: activeInfoDisplays.IndexOf(InfoAction.DAMAGE_DEALT_PER_SECOND_DISPLAY)
   );
   UpdateButtonAppearance(MenuState.INFORMATION, 3, 3, "Hide DPS Dealt", Color.Gray);
@@ -59,9 +59,9 @@ if (activeInfoDisplays.Contains(InfoAction.DAMAGE_RECEIVED_PER_SECOND_DISPLAY))
 {
   infoDisplayEntities[InfoAction.DAMAGE_RECEIVED_PER_SECOND_DISPLAY] = CreateHudText(
     VisibleTo: EventPlayer().currentMenuState == MenuState.CLOSED ? EventPlayer() : null,
-    Header: <"DPS Received: <0>", UpdateEveryFrame((damageReceivedInPeriod) / durationToAverageOver)>,
-    Subheader: <"Self: <0>", Max(0, UpdateEveryFrame((damageReceivedInPeriod - damageReceivedInPeriodNonSelf) / durationToAverageOver))>,
-    Text: <"Other: <0><1>", UpdateEveryFrame((damageReceivedInPeriodNonSelf) / durationToAverageOver), MANY_SPACES>,
+    Header: <"DPS Received: <0>", UpdateEveryFrame((damageReceivedInPeriod) / DURATION_TO_AVERAGE_OVER)>,
+    Subheader: <"Self: <0>", Max(0, UpdateEveryFrame((damageReceivedInPeriod - damageReceivedInPeriodNonSelf) / DURATION_TO_AVERAGE_OVER))>,
+    Text: <"Other: <0><1>", UpdateEveryFrame((damageReceivedInPeriodNonSelf) / DURATION_TO_AVERAGE_OVER), MANY_SPACES>,
     SortOrder: activeInfoDisplays.IndexOf(InfoAction.DAMAGE_RECEIVED_PER_SECOND_DISPLAY)
   );
   UpdateButtonAppearance(MenuState.INFORMATION, 3, 4, "Hide DPS Received", Color.Gray);

--- a/interface/modifications/modsMenu.ostw
+++ b/interface/modifications/modsMenu.ostw
@@ -178,7 +178,7 @@ Event.OngoingPlayer
 if (NormalizedHealth() < 1)
 {
   Wait(AllSupportHeroes().Contains(EffectiveHero()) ? 2.45 : MaxHealthOfType(EventPlayer(), HealthType.Shields) > 0 ? 2.95 : 4.95, WaitBehavior.AbortWhenFalse);
-  LoopIf(HasStatus(EventPlayer(), Status.Asleep) && !IsModificationActive(Modification.DISABLE_SUPPORT_PASSIVE) && !isPunchingBag);
+  LoopIf(HasStatus(EventPlayer(), Status.Asleep) || (!IsModificationActive(Modification.DISABLE_SUPPORT_PASSIVE) && !isPunchingBag));
   if (Health() <= 0.001) SetPlayerHealth(EventPlayer(), 0.002);
   Damage(EventPlayer(), null, 0.001);
   Heal(EventPlayer(), null, 0.001);

--- a/interface/modifications/modsMenu.ostw
+++ b/interface/modifications/modsMenu.ostw
@@ -173,8 +173,8 @@ if (IsModificationActive(Modification.DISABLE_SUPPORT_PASSIVE))
 
 rule: "[interface/modifications/modsMenu.ostw] Handle preventing heal passive"
 Event.OngoingPlayer
-// if (IsModificationActive(Modification.DISABLE_SUPPORT_PASSIVE))
-// if (AllSupportHeroes().Contains(IsDuplicating() ? HeroBeingDuplicated() : HeroOf()))
+if (HasSpawned())
+if (IsAlive())
 if (NormalizedHealth() < 1)
 {
   Wait(AllSupportHeroes().Contains(EffectiveHero()) ? 2.45 : MaxHealthOfType(EventPlayer(), HealthType.Shields) > 0 ? 2.95 : 4.95, WaitBehavior.AbortWhenFalse);

--- a/interface/tools/invisibility.del
+++ b/interface/tools/invisibility.del
@@ -31,10 +31,10 @@ void AddOnePhasedOutLock()
 
 void RemoveOneInvisibilityLock()
 {
-  invisibilityLockCount = Max(0, invisibilityLockCount - 1);
+  invisibilityLockCount -= 1;
 }
 
 void RemoveOnePhasedOutLock()
 {
-  phasedOutLockCount = Max(0, phasedOutLockCount - 1);
+  phasedOutLockCount -= 1;
 }

--- a/interface/tools/thirdPerson.ostw
+++ b/interface/tools/thirdPerson.ostw
@@ -13,8 +13,9 @@ playervar Number thirdPersonHeight = 0;
 rule: "[interface/tools/thirdPerson.ostw] When person is in third person and their menu state becomes closed, start third person camera"
 Event.OngoingPlayer
 if (IsAlive())
-if (([Hero.Widowmaker, Hero.Ashe, Hero.Ana].Contains(HeroOf()) && IsFiringSecondary()) == false)
+if (([Hero.Widowmaker, Hero.Ashe, Hero.Ana].Contains(EffectiveHero()) && IsFiringSecondary()) == false)
 if (thirdPersonState != ThirdPersonState.OFF)
+if (!isNoClipActive)
 if (currentMenuState == MenuState.CLOSED)
 {
   MinWait();
@@ -33,6 +34,7 @@ if (currentMenuState == MenuState.CLOSED)
     LookAtPosition: RayCastHitPosition(EyePosition(), EyePosition() + FacingDirectionOf() * 200, AllPlayers(), EventPlayer(), false),
     BlendSpeed: 60
   );
+  // Stopping camera is handled by the fact that third person must be stopped by opening the menu.
 }
 
 rule: "[interface/tools/thirdPerson.ostw] During adjustment, reduce move speed"

--- a/interface/tools/toolsMenu.ostw
+++ b/interface/tools/toolsMenu.ostw
@@ -290,8 +290,9 @@ void ToggleThirdPerson()
 void ResetState()
 {
   UnlockAllButtons();
-  phasedOutLockCount = 0;
-  invisibilityLockCount = 0;
+  AddOneLockToAllButtons();
+  phasedOutLockCount = 1;
+  invisibilityLockCount = 1;
   CloseMenu(EventPlayer());
 }
 

--- a/lib/metrics/config.del
+++ b/lib/metrics/config.del
@@ -1,4 +1,6 @@
 globalvar Boolean OptimizeMetricsForOverTime = WorkshopSettingCombo(InformationCategory, "HPS/DPS Meter Optimization", 0, ["Normal", "Over Time"], 0) == 1;
+Number[] METRICS_UPDATE_PERIODS: [1, 2, 4, 6, 10];
+globalvar Number MetricsUpdatePeriod = METRICS_UPDATE_PERIODS[WorkshopSettingCombo(InformationCategory, "HPS/DPS Meter Accuracy", 0, ["Perfect (1 Tick | Highest Script Load)", "Almost Perfect (2 Ticks | Higher Script Load)", "Good (4 Ticks | High Script Load)", "Fair (6 Ticks | Medium Script Load)", "Poor (10 Ticks | Light Script Load)"], 0)] * TICK_LENGTH;
 Number OVER_TIME_PERIOD: 0.192;
 Number PERIODS_IN_ONE_SECOND: RoundToInteger(1 / OVER_TIME_PERIOD, Rounding.Down);
 

--- a/lib/metrics/config.del
+++ b/lib/metrics/config.del
@@ -1,7 +1,7 @@
 globalvar Boolean OptimizeMetricsForOverTime = WorkshopSettingCombo(InformationCategory, "HPS/DPS Meter Optimization", 0, ["Normal", "Over Time"], 0) == 1;
-Number healOverTimePeriod: 0.192;
-Number healOverTimePeriodsInOneSecond: RoundToInteger(1 / healOverTimePeriod, Rounding.Down);
+Number OVER_TIME_PERIOD: 0.192;
+Number PERIODS_IN_ONE_SECOND: RoundToInteger(1 / OVER_TIME_PERIOD, Rounding.Down);
 
 // Number durationToAverageOver: OptimizeMetricsForOverTime ? healOverTimePeriod * healOverTimePeriodsInOneSecond : 1;
-Number durationToAverageOver: OptimizeMetricsForOverTime ? healOverTimePeriod * 2 : 1;
-Number perSecondBufferRetentionSeconds: 0.25;
+Number DURATION_TO_AVERAGE_OVER: OptimizeMetricsForOverTime ? OVER_TIME_PERIOD * 2 : 1;
+Number PER_SECOND_BUFFER_RETENTION: 0.25;

--- a/lib/metrics/damagePerSecond.ostw
+++ b/lib/metrics/damagePerSecond.ostw
@@ -18,6 +18,7 @@ playervar Number damageDealtInPeriodNonSelf;
 rule: "[lib/damagePerSecond.ostw] Track when a player receives damage"
 Event.OnDamageTaken
 if (EventDamage() > 0)
+if (AllPlayers().Any(p => p.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_NUMBERS)))
 {
   eventTimestamp = TotalTimeElapsed();
   Victim().damageReceivedEvents = Victim().damageReceivedEvents.Append({ timestamp: eventTimestamp, amount: EventDamage(), attacker: Attacker(), victim: Victim() });

--- a/lib/metrics/damagePerSecond.ostw
+++ b/lib/metrics/damagePerSecond.ostw
@@ -18,17 +18,18 @@ playervar Number damageDealtInPeriodNonSelf;
 rule: "[lib/damagePerSecond.ostw] Track when a player receives damage"
 Event.OnDamageTaken
 if (EventDamage() > 0)
-if (AllPlayers().Any(p => p.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_NUMBERS)))
+if (AllPlayers().Any(p => p.activeInfoDisplays.Contains(InfoAction.DAMAGE_DEALT_PER_SECOND_DISPLAY)
+  || p.activeInfoDisplays.Contains(InfoAction.DAMAGE_RECEIVED_PER_SECOND_DISPLAY)))
 {
   eventTimestamp = TotalTimeElapsed();
   Victim().damageReceivedEvents = Victim().damageReceivedEvents.Append({ timestamp: eventTimestamp, amount: EventDamage(), attacker: Attacker(), victim: Victim() });
   Attacker().damageDealtEvents = Attacker().damageDealtEvents.Append({ timestamp: eventTimestamp, amount: EventDamage(), attacker: Attacker(), victim: Victim() });
 
-  if (eventTimestamp < Victim().damageReceivedEvents.First.timestamp + durationToAverageOver) {
+  if (eventTimestamp < Victim().damageReceivedEvents.First.timestamp + DURATION_TO_AVERAGE_OVER) {
     Victim().damageReceivedInPeriod += EventDamage();
     if (Attacker() != Victim()) Victim().damageReceivedInPeriodNonSelf += EventDamage();
   }
-  if (eventTimestamp < Attacker().damageDealtEvents.First.timestamp + durationToAverageOver) {
+  if (eventTimestamp < Attacker().damageDealtEvents.First.timestamp + DURATION_TO_AVERAGE_OVER) {
     Attacker().damageDealtInPeriod += EventDamage();
     if (Attacker() != Victim()) Attacker().damageDealtInPeriodNonSelf += EventDamage();
   }
@@ -37,16 +38,16 @@ if (AllPlayers().Any(p => p.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_N
 rule: "[lib/damagePerSecond.ostw] When the head of the damage received array has expired, remove all expired events"
 Event.OngoingPlayer
 if (damageReceivedEvents.Length > 0)
-if (UpdateEveryFrame(TotalTimeElapsed()) >= damageReceivedEvents.First.timestamp + durationToAverageOver + perSecondBufferRetentionSeconds)
+if (UpdateEveryFrame(TotalTimeElapsed()) >= damageReceivedEvents.First.timestamp + DURATION_TO_AVERAGE_OVER + PER_SECOND_BUFFER_RETENTION)
 {
-  oldTimeAcceptanceThreshold = damageReceivedEvents.First.timestamp + durationToAverageOver;
+  oldTimeAcceptanceThreshold = damageReceivedEvents.First.timestamp + DURATION_TO_AVERAGE_OVER;
   // LogToInspector(<"Old time window: <0> - <1>", damageReceivedEvents.First.timestamp, oldTimeAcceptanceThreshold>);
   structArraysStartIndex = 0;
   structArraysCount = damageReceivedEvents.Length;
   // LogToInspector(<"Initial conditions | damageReceivedInPastSecond: <0> | damageReceivedInPastSecondNonSelf: <1>", damageReceivedInPastSecond, damageReceivedInPastSecondNonSelf>);
 
   # Remove expired events
-  while (damageReceivedEvents[structArraysStartIndex].timestamp + durationToAverageOver + perSecondBufferRetentionSeconds < TotalTimeElapsed() && structArraysStartIndex < damageReceivedEvents.Length) {
+  while (damageReceivedEvents[structArraysStartIndex].timestamp + DURATION_TO_AVERAGE_OVER + PER_SECOND_BUFFER_RETENTION < TotalTimeElapsed() && structArraysStartIndex < damageReceivedEvents.Length) {
     damageReceivedInPeriod = Max(0, damageReceivedInPeriod - damageReceivedEvents[structArraysStartIndex].amount);
     // LogToInspector(<"Index <0> with timestamp <1> expired, removing <2> for <3>", structArraysStartIndex, damageReceivedEvents[structArraysStartIndex].timestamp, damageReceivedEvents[structArraysStartIndex].amount, damageReceivedInPastSecond>);
     if (damageReceivedEvents[structArraysStartIndex].victim != damageReceivedEvents[structArraysStartIndex].attacker) {
@@ -59,7 +60,7 @@ if (UpdateEveryFrame(TotalTimeElapsed()) >= damageReceivedEvents.First.timestamp
   sweepNewlyValidEventsIndex = structArraysStartIndex;
   // LogToInspector(<"New start index: <2> | New time window: <0> - <1>", damageReceivedEvents[structArraysStartIndex].timestamp, damageReceivedEvents[structArraysStartIndex].timestamp + durationToAverageOver, structArraysStartIndex>);
   # Add newly valid events
-  while (damageReceivedEvents[sweepNewlyValidEventsIndex].timestamp < damageReceivedEvents[structArraysStartIndex].timestamp + durationToAverageOver && sweepNewlyValidEventsIndex < damageReceivedEvents.Length) {
+  while (damageReceivedEvents[sweepNewlyValidEventsIndex].timestamp < damageReceivedEvents[structArraysStartIndex].timestamp + DURATION_TO_AVERAGE_OVER && sweepNewlyValidEventsIndex < damageReceivedEvents.Length) {
     // LogToInspector(<"index: <0> | timestamp: <1> | damageReceivedInPastSecond: <2> | damageReceivedInPastSecondNonSelf: <3>", sweepNewlyValidEventsIndex, damageReceivedEvents[sweepNewlyValidEventsIndex].timestamp, damageReceivedInPastSecond, damageReceivedInPastSecondNonSelf>);
     # Make sure to only include NEWLY valid events
     if (damageReceivedEvents[sweepNewlyValidEventsIndex].timestamp >= oldTimeAcceptanceThreshold) {
@@ -74,23 +75,23 @@ if (UpdateEveryFrame(TotalTimeElapsed()) >= damageReceivedEvents.First.timestamp
   }
   # Slice arrays instead of doing incremental updates for perf
   damageReceivedEvents = damageReceivedEvents.Slice(structArraysStartIndex, structArraysCount);
-  MinWait();
+  Wait(MetricsUpdatePeriod);
   LoopIfConditionIsTrue();
 }
 
 rule: "[lib/damagePerSecond.ostw] When the head of the damage dealt array has expired, remove all expired events"
 Event.OngoingPlayer
 if (damageDealtEvents.Length > 0)
-if (UpdateEveryFrame(TotalTimeElapsed()) >= damageDealtEvents.First.timestamp + durationToAverageOver + perSecondBufferRetentionSeconds)
+if (UpdateEveryFrame(TotalTimeElapsed()) >= damageDealtEvents.First.timestamp + DURATION_TO_AVERAGE_OVER + PER_SECOND_BUFFER_RETENTION)
 {
-  oldTimeAcceptanceThreshold = damageDealtEvents.First.timestamp + durationToAverageOver;
+  oldTimeAcceptanceThreshold = damageDealtEvents.First.timestamp + DURATION_TO_AVERAGE_OVER;
   // LogToInspector(<"NEW RUN\nOld time window: <0> - <1>", damageDealtEvents.First.timestamp, oldTimeAcceptanceThreshold>);
   structArraysStartIndex = 0;
   structArraysCount = damageDealtEvents.Length;
   // LogToInspector(<"Initial conditions | damageReceivedInPastSecond: <0> | damageReceivedInPastSecondNonSelf: <1>", damageDealtInPastSecond, damageDealtInPastSecondNonSelf>);
 
   # Remove expired events
-  while (damageDealtEvents[structArraysStartIndex].timestamp + durationToAverageOver + perSecondBufferRetentionSeconds < TotalTimeElapsed() && structArraysStartIndex < damageDealtEvents.Length) {
+  while (damageDealtEvents[structArraysStartIndex].timestamp + DURATION_TO_AVERAGE_OVER + PER_SECOND_BUFFER_RETENTION < TotalTimeElapsed() && structArraysStartIndex < damageDealtEvents.Length) {
     damageDealtInPeriod = Max(0, damageDealtInPeriod - damageDealtEvents[structArraysStartIndex].amount);
     // LogToInspector(<"Index <0> with timestamp <1> expired, removing <2> for <3>", structArraysStartIndex, damageDealtEvents[structArraysStartIndex].timestamp, damageDealtEvents[structArraysStartIndex].amount, damageDealtInPastSecond>);
     if (damageDealtEvents[structArraysStartIndex].victim != damageDealtEvents[structArraysStartIndex].attacker) {
@@ -103,7 +104,7 @@ if (UpdateEveryFrame(TotalTimeElapsed()) >= damageDealtEvents.First.timestamp + 
   sweepNewlyValidEventsIndex = structArraysStartIndex;
   // LogToInspector(<"New start index: <2> | New time window: <0> - <1>", damageDealtEvents[structArraysStartIndex].timestamp, damageDealtEvents[structArraysStartIndex].timestamp + durationToAverageOver, structArraysStartIndex>);
   # Add newly valid events
-  while (damageDealtEvents[sweepNewlyValidEventsIndex].timestamp < damageDealtEvents[structArraysStartIndex].timestamp + durationToAverageOver && sweepNewlyValidEventsIndex < damageDealtEvents.Length) {
+  while (damageDealtEvents[sweepNewlyValidEventsIndex].timestamp < damageDealtEvents[structArraysStartIndex].timestamp + DURATION_TO_AVERAGE_OVER && sweepNewlyValidEventsIndex < damageDealtEvents.Length) {
     // LogToInspector(<"index: <0> | timestamp: <1> | damageReceivedInPastSecond: <2> | damageReceivedInPastSecondNonSelf: <3>", sweepNewlyValidEventsIndex, damageDealtEvents[sweepNewlyValidEventsIndex].timestamp, damageDealtInPastSecond, damageDealtInPastSecondNonSelf>);
     # Make sure to only include NEWLY valid events
     if (damageDealtEvents[sweepNewlyValidEventsIndex].timestamp >= oldTimeAcceptanceThreshold) {
@@ -118,6 +119,6 @@ if (UpdateEveryFrame(TotalTimeElapsed()) >= damageDealtEvents.First.timestamp + 
   }
   # Slice arrays instead of doing incremental updates for perf
   damageDealtEvents = damageDealtEvents.Slice(structArraysStartIndex, structArraysCount);
-  MinWait();
+  Wait(MetricsUpdatePeriod);
   LoopIfConditionIsTrue();
 }

--- a/lib/metrics/diagnostics.del
+++ b/lib/metrics/diagnostics.del
@@ -1,0 +1,62 @@
+Color[] gradientColors: [Color.Green, Color.LimeGreen, Color.Yellow, Color.Orange, Color.Red];
+import "../../OSTWUtils/Colors.del";
+// String DebugSettingsCategory: "99. Debug";
+
+void CreateDiagnostic(in String Text, in Color Color, in Number SortOrder) {
+  CreateHudText(
+    VisibleTo:      HostPlayer(),
+    Subheader:      Text,
+    Location:       Location.Right,
+    SubheaderColor: Color,
+    SortOrder:      SortOrder,
+    Reevaluation:   HudTextRev.VisibleToStringAndColor,
+    Spectators:     Spectators.VisibleAlways
+  );
+}
+
+rule: "[DEBUG | main.ostw] Show diagnostics"
+if (WorkshopSettingToggle(DebugSettingsCategory, "Show Diagnostics", true))
+{
+  CreateDiagnostic(
+    Text:           "[ {0} ]  Server Load".Format([ServerLoad()]),
+    Color:          Colors.StepGradient(gradientColors, ServerLoad()/255),
+    SortOrder:      1);
+  CreateDiagnostic(
+    Text:           "[ {0} ]  Server Load Average".Format([ServerLoadAverage()]),
+    Color:          Colors.StepGradient(gradientColors, ServerLoadAverage()/255),
+    SortOrder:      2);
+  CreateDiagnostic(
+    Text:           "[ {0} ]  Server Load Peak".Format([ServerLoadPeak()]),
+    Color:          Colors.StepGradient(gradientColors, ServerLoadPeak()/255),
+    SortOrder:      3);
+  CreateDiagnostic(
+    Text:           <"[ <0> / <1> ]  Entity Count", EntityCount(), 128>,
+    Color:          Colors.StepGradient(gradientColors, EntityCount()/128),
+    SortOrder:      4);
+  CreateDiagnostic(
+    Text:           <"[ <0> / <1> ]  Text Count", TextCount(), 128>,
+    Color:          Colors.StepGradient(gradientColors, TextCount() / 128),
+    SortOrder:      5);
+  CreateDiagnostic(
+    Text:           <"[ <0> / <1> ]  Dummy Bot Count", DummyBotCount(), 12 - HumanAndAICount()>,
+    Color:          Colors.StepGradient(gradientColors, DummyBotCount() / (12 - HumanAndAICount())),
+    SortOrder:      6);
+  CreateDiagnostic(
+    Text:           <"Invis Lock Count: <0>", LocalPlayer().invisibilityLockCount>,
+    Color:          LocalPlayer().invisibilityLockCount > 0
+                      ? Color.Green
+                      : LocalPlayer().invisibilityLockCount < 0
+                        ? Color.Red
+                        : Color.White,
+    SortOrder:      7
+  );
+  CreateDiagnostic(
+    Text:           <"Phased Out Count: <0>", LocalPlayer().phasedOutLockCount>,
+    Color:          LocalPlayer().phasedOutLockCount > 0
+                      ? Color.Green
+                      : LocalPlayer().phasedOutLockCount < 0
+                        ? Color.Red
+                        : Color.White,
+    SortOrder:      8
+  );
+}

--- a/lib/metrics/healingPerSecond.ostw
+++ b/lib/metrics/healingPerSecond.ostw
@@ -18,17 +18,18 @@ playervar Number healDealtInPeriodNonSelf;
 rule: "[lib/healingPerSecond.ostw] Track when a player receives healing"
 Event.OnHealingTaken
 if (EventHealing() > 0)
-if (AllPlayers().Any(p => p.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_NUMBERS)))
+if (AllPlayers().Any(p => p.activeInfoDisplays.Contains(InfoAction.HEALING_DEALT_PER_SECOND_DISPLAY)
+  || p.activeInfoDisplays.Contains(InfoAction.HEALING_RECEIVED_PER_SECOND_DISPLAY)))
 {
   eventTimestamp = TotalTimeElapsed();
   Healee().healingReceivedEvents = Healee().healingReceivedEvents.Append({ timestamp: eventTimestamp, amount: EventHealing(), healer: Healer(), healee: Healee() });
   Healer().healingDealtEvents = Healer().healingDealtEvents.Append({ timestamp: eventTimestamp, amount: EventHealing(), healer: Healer(), healee: Healee() });
 
-  if (eventTimestamp < Healee().healingReceivedEvents.First.timestamp + durationToAverageOver) {
+  if (eventTimestamp < Healee().healingReceivedEvents.First.timestamp + DURATION_TO_AVERAGE_OVER) {
     Healee().healReceivedInPeriod += EventHealing();
     if (Healer() != Healee()) Healee().healReceivedInPeriodNonSelf += EventHealing();
   }
-  if (eventTimestamp < Healer().healingDealtEvents.First.timestamp + durationToAverageOver) {
+  if (eventTimestamp < Healer().healingDealtEvents.First.timestamp + DURATION_TO_AVERAGE_OVER) {
     Healer().healDealtInPeriod += EventHealing();
     if (Healer() != Healee()) Healer().healDealtInPeriodNonSelf += EventHealing();
   }
@@ -37,14 +38,14 @@ if (AllPlayers().Any(p => p.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_N
 rule: "[lib/healingPerSecond.ostw] When the head of the healing received array has expired, remove all expired events"
 Event.OngoingPlayer
 if (healingReceivedEvents.Length > 0)
-if (UpdateEveryFrame(TotalTimeElapsed()) >= healingReceivedEvents.First.timestamp + durationToAverageOver + perSecondBufferRetentionSeconds)
+if (UpdateEveryFrame(TotalTimeElapsed()) >= healingReceivedEvents.First.timestamp + DURATION_TO_AVERAGE_OVER + PER_SECOND_BUFFER_RETENTION)
 {
-  oldTimeAcceptanceThreshold = healingReceivedEvents.First.timestamp + durationToAverageOver;
+  oldTimeAcceptanceThreshold = healingReceivedEvents.First.timestamp + DURATION_TO_AVERAGE_OVER;
   structArraysStartIndex = 0;
   structArraysCount = healingReceivedEvents.Length;
 
   # Remove expired events
-  while (healingReceivedEvents[structArraysStartIndex].timestamp + durationToAverageOver + perSecondBufferRetentionSeconds < TotalTimeElapsed() && structArraysStartIndex < healingReceivedEvents.Length) {
+  while (healingReceivedEvents[structArraysStartIndex].timestamp + DURATION_TO_AVERAGE_OVER + PER_SECOND_BUFFER_RETENTION < TotalTimeElapsed() && structArraysStartIndex < healingReceivedEvents.Length) {
     healReceivedInPeriod = Max(0, healReceivedInPeriod - healingReceivedEvents[structArraysStartIndex].amount);
     if (healingReceivedEvents[structArraysStartIndex].healee != healingReceivedEvents[structArraysStartIndex].healer)
       healReceivedInPeriodNonSelf = Max(0, healReceivedInPeriodNonSelf - healingReceivedEvents[structArraysStartIndex].amount);
@@ -60,7 +61,7 @@ if (UpdateEveryFrame(TotalTimeElapsed()) >= healingReceivedEvents.First.timestam
   }
   sweepNewlyValidEventsIndex = structArraysStartIndex;
   # Add newly valid events
-  while (healingReceivedEvents[sweepNewlyValidEventsIndex].timestamp < healingReceivedEvents[structArraysStartIndex].timestamp + durationToAverageOver && sweepNewlyValidEventsIndex < healingReceivedEvents.Length) {
+  while (healingReceivedEvents[sweepNewlyValidEventsIndex].timestamp < healingReceivedEvents[structArraysStartIndex].timestamp + DURATION_TO_AVERAGE_OVER && sweepNewlyValidEventsIndex < healingReceivedEvents.Length) {
     # Make sure to only include NEWLY valid events
     if (healingReceivedEvents[sweepNewlyValidEventsIndex].timestamp >= oldTimeAcceptanceThreshold) {
       healReceivedInPeriod += healingReceivedEvents[sweepNewlyValidEventsIndex].amount;
@@ -79,14 +80,14 @@ if (UpdateEveryFrame(TotalTimeElapsed()) >= healingReceivedEvents.First.timestam
 rule: "[lib/healingPerSecond.ostw] When the head of the healing dealt array has expired, remove all expired events"
 Event.OngoingPlayer
 if (healingDealtEvents.Length > 0)
-if (UpdateEveryFrame(TotalTimeElapsed()) >= healingDealtEvents.First.timestamp + durationToAverageOver + perSecondBufferRetentionSeconds)
+if (UpdateEveryFrame(TotalTimeElapsed()) >= healingDealtEvents.First.timestamp + DURATION_TO_AVERAGE_OVER + PER_SECOND_BUFFER_RETENTION)
 {
-  oldTimeAcceptanceThreshold = healingDealtEvents.First.timestamp + durationToAverageOver;
+  oldTimeAcceptanceThreshold = healingDealtEvents.First.timestamp + DURATION_TO_AVERAGE_OVER;
   structArraysStartIndex = 0;
   structArraysCount = healingDealtEvents.Length;
 
   # Remove expired events
-  while (healingDealtEvents[structArraysStartIndex].timestamp + durationToAverageOver + perSecondBufferRetentionSeconds < TotalTimeElapsed() && structArraysStartIndex < healingDealtEvents.Length) {
+  while (healingDealtEvents[structArraysStartIndex].timestamp + DURATION_TO_AVERAGE_OVER + PER_SECOND_BUFFER_RETENTION < TotalTimeElapsed() && structArraysStartIndex < healingDealtEvents.Length) {
     healDealtInPeriod = Max(0, healDealtInPeriod - healingDealtEvents[structArraysStartIndex].amount);
     if (healingDealtEvents[structArraysStartIndex].healee != healingDealtEvents[structArraysStartIndex].healer)
       healDealtInPeriodNonSelf = Max(0, healDealtInPeriodNonSelf - healingDealtEvents[structArraysStartIndex].amount);
@@ -102,7 +103,7 @@ if (UpdateEveryFrame(TotalTimeElapsed()) >= healingDealtEvents.First.timestamp +
   }
   sweepNewlyValidEventsIndex = structArraysStartIndex;
   # Add newly valid events
-  while (healingDealtEvents[sweepNewlyValidEventsIndex].timestamp < healingDealtEvents[structArraysStartIndex].timestamp + durationToAverageOver && sweepNewlyValidEventsIndex < healingDealtEvents.Length) {
+  while (healingDealtEvents[sweepNewlyValidEventsIndex].timestamp < healingDealtEvents[structArraysStartIndex].timestamp + DURATION_TO_AVERAGE_OVER && sweepNewlyValidEventsIndex < healingDealtEvents.Length) {
     # Make sure to only include NEWLY valid events
     if (healingDealtEvents[sweepNewlyValidEventsIndex].timestamp >= oldTimeAcceptanceThreshold) {
       healDealtInPeriod += healingDealtEvents[sweepNewlyValidEventsIndex].amount;

--- a/lib/metrics/healingPerSecond.ostw
+++ b/lib/metrics/healingPerSecond.ostw
@@ -18,6 +18,7 @@ playervar Number healDealtInPeriodNonSelf;
 rule: "[lib/healingPerSecond.ostw] Track when a player receives healing"
 Event.OnHealingTaken
 if (EventHealing() > 0)
+if (AllPlayers().Any(p => p.activeInfoDisplays.Contains(InfoAction.DAMAGE_HEAL_NUMBERS)))
 {
   eventTimestamp = TotalTimeElapsed();
   Healee().healingReceivedEvents = Healee().healingReceivedEvents.Append({ timestamp: eventTimestamp, amount: EventHealing(), healer: Healer(), healee: Healee() });

--- a/lib/metrics/shared.del
+++ b/lib/metrics/shared.del
@@ -1,5 +1,5 @@
-playervar Number structArraysStartIndex!;
-playervar Number structArraysCount!;
-playervar Number sweepNewlyValidEventsIndex!;
-playervar Number oldTimeAcceptanceThreshold!;
-playervar Number eventTimestamp!;
+playervar Number structArraysStartIndex;
+playervar Number structArraysCount;
+playervar Number sweepNewlyValidEventsIndex;
+playervar Number oldTimeAcceptanceThreshold;
+playervar Number eventTimestamp;

--- a/lib/player/buttonControl.del
+++ b/lib/player/buttonControl.del
@@ -57,7 +57,7 @@ void AddOneLockToAllButtons(in Player player = EventPlayer())
 
 void RemoveOneLockFromAllButtons(in Player player = EventPlayer())
 {
-  player.buttonLocks = player.buttonLocks.Map((lockCount) => Max(0, lockCount - 1));
+  player.buttonLocks = player.buttonLocks.Map((lockCount) => lockCount - 1);
   UpdatePlayerButtonStatus(player);
 }
 
@@ -75,7 +75,7 @@ void AddOneLockToButton(in Player player = EventPlayer(), in Button button)
 
 void RemoveOneLockFromButton(in Player player = EventPlayer(), in Button button)
 {
-  player.buttonLocks[AllButtons.IndexOf(button)] = Max(0, player.buttonLocks[AllButtons.IndexOf(button)] - 1);
+  player.buttonLocks[AllButtons.IndexOf(button)] -= 1;
   if (player.buttonLocks[AllButtons.IndexOf(button)] == 0) AllowButton(player, button);
 }
 

--- a/lib/player/noClip.del
+++ b/lib/player/noClip.del
@@ -26,18 +26,33 @@ if (isNoClipActive)
   SetMoveSpeed(EventPlayer(), 0);
   AddOneLockToButton(button: Button.Jump);
   AddOneLockToButton(button: Button.Crouch);
-}
+  AddOneInvisibilityLock();
+  AddOnePhasedOutLock();
 
-rule: "[lib/player/noClip.del] Disengage noclip"
-Event.OngoingPlayer
-if (!isNoClipActive)
-{
+  WaitUntil(!isNoClipActive, 1000000);
+
   SetGravity(EventPlayer(), 100);
   EnableMovementCollisionWithEnvironment(EventPlayer());
   EnableMovementCollisionWithPlayers(EventPlayer());
   SetMoveSpeed(EventPlayer(), 100);
   RemoveOneLockFromButton(button: Button.Jump);
   RemoveOneLockFromButton(button: Button.Crouch);
+  RemoveOneInvisibilityLock();
+  RemoveOnePhasedOutLock();
+}
+
+rule: "[lib/player/noClip.del] Noclip camera"
+Event.OngoingPlayer
+if (isNoClipActive)
+if (currentMenuState == MenuState.CLOSED)
+{
+  MinWait();
+  // Stopping camera is handled by the fact that noclip must be stopped by opening menu.
+  StartCamera(
+    Player:               EventPlayer(),
+    EyePosition:          UpdateEveryFrame(EventPlayer().EyePosition()),
+    LookAtPosition:       UpdateEveryFrame(EventPlayer().EyePosition() + EventPlayer().FacingDirection()),
+    BlendSpeed:           1000);
 }
 
 rule: "Noclip propulsion"

--- a/lib/player/noClip.del
+++ b/lib/player/noClip.del
@@ -55,26 +55,31 @@ if (currentMenuState == MenuState.CLOSED)
     BlendSpeed:           1000);
 }
 
+Boolean NOCLIP_THROTTLING(Player p = EventPlayer()): (
+  IsButtonHeld(p, Button.Crouch)
+  || IsButtonHeld(p, Button.Jump)
+  || ThrottleOf(p) != Vector(0, 0, 0));
+
 rule: "Noclip propulsion"
 Event.OngoingPlayer
 if (isNoClipActive)
-if ((IsButtonHeld(EventPlayer(), Button.Crouch) || IsButtonHeld(EventPlayer(), Button.Jump) || ThrottleOf(EventPlayer()) != Vector(0, 0, 0)))
+if (NOCLIP_THROTTLING())
 {
     ApplyImpulse(EventPlayer(), VelocityOf(EventPlayer()) * -1, SpeedOf(EventPlayer()) * 0.03, Relative.ToWorld, ContraryMotion.Incorporate);
     if (!(IsButtonHeld(Button: Button.Crouch) && IsButtonHeld(Button: Button.Jump) && MagnitudeOf(ThrottleOf()) == 0)) {
-      ApplyImpulse(EventPlayer(), Normalize(FacingDirectionOf(EventPlayer()) * ZOf(ThrottleOf(EventPlayer())) + WorldVectorOf(Left(), EventPlayer(), LocalVector.Rotation) * XOf(ThrottleOf(EventPlayer())) + Up() * (IsButtonHeld(EventPlayer(), Button.Jump) - IsButtonHeld(EventPlayer(), Button.Crouch))), (100 + 300 * IsButtonHeld(EventPlayer(), Button.Reload) - SpeedOf(EventPlayer())) / 62.5, Relative.ToWorld, ContraryMotion.Incorporate);
+      ApplyImpulse(EventPlayer(), Normalize(FacingDirectionOf(EventPlayer()) * ZOf(ThrottleOf(EventPlayer())) + WorldVectorOf(Left(), EventPlayer(), LocalVector.Rotation) * XOf(ThrottleOf(EventPlayer())) + Up() * (IsButtonHeld(EventPlayer(), Button.Jump) - IsButtonHeld(EventPlayer(), Button.Crouch))), (100 + 300 * IsButtonHeld(EventPlayer(), Button.Reload) - SpeedOf(EventPlayer())) / 31.25, Relative.ToWorld, ContraryMotion.Incorporate);
     }
-    MinWait();
+    Wait(0.064);
     LoopIfConditionIsTrue();
 }
 
 rule: "Noclip air resistance"
 Event.OngoingPlayer
 if (isNoClipActive)
-if (!(IsButtonHeld(EventPlayer(), Button.Crouch) || IsButtonHeld(EventPlayer(), Button.Jump) || ThrottleOf(EventPlayer()) != Vector(0, 0, 0)))
+if (NOCLIP_THROTTLING() == false)
 if (SpeedOf(EventPlayer()) > 0.01)
 {
-    ApplyImpulse(EventPlayer(), VelocityOf(EventPlayer()) * -1, SpeedOf(EventPlayer()) * 0.12, Relative.ToWorld, ContraryMotion.Incorporate);
-    MinWait();
+    ApplyImpulse(EventPlayer(), VelocityOf(EventPlayer()) * -1, SpeedOf(EventPlayer()) * 0.2, Relative.ToWorld, ContraryMotion.Incorporate);
+    Wait(0.064);
     LoopIfConditionIsTrue();
 }

--- a/main.ostw
+++ b/main.ostw
@@ -43,22 +43,54 @@ String MenuSettingsCategory: "03. Menu Settings";
 String ModSettingsCategory: "04. Mod Settings";
 String InformationCategory: "05. Information";
 String BotAndReplaySettingsCategory: "06. Bot and Replay";
-String DebugSettingsCategory: "19. Debug";
+String DebugSettingsCategory: "99. Debug";
 
 globalvar Number i;
 
 // DEBUG: Diagnostics
-// import "./OSTWUtils/Diagnostics.del";
-// rule: "[DEBUG | main.ostw] Show diagnostics"
-// {
-//   new Diagnostics(
-//     ShowEntityCount: true,
-//     ShowTextCount: true,
-//     ShowServerLoad: true,
-//     ShowServerLoadAverage: true,
-//     ShowServerLoadPeak: true);
-//   // printMenuValues();
-// }
+Number DummyBotCount(): CountOf(FilteredArray(AllPlayers(), IsDummyBot(ArrayElement())));
+Number HumanAndAICount(): CountOf(FilteredArray(AllPlayers(), !IsDummyBot(ArrayElement())));
+globalvar Color[] gradientColors! = [Color.Green, Color.LimeGreen, Color.Yellow, Color.Orange, Color.Red];
+import "OSTWUtils/Colors.del";
+void CreateDiagnostic(in String Text, in Color Color, in Number SortOrder) {
+  CreateHudText(
+    VisibleTo:      HostPlayer(),
+    Subheader:      Text,
+    Location:       Location.Right,
+    SubheaderColor: Color,
+    SortOrder:      SortOrder,
+    Reevaluation:   HudTextRev.VisibleToStringAndColor,
+    Spectators:     Spectators.VisibleAlways
+  );
+}
+rule: "[DEBUG | main.ostw] Show diagnostics"
+if (WorkshopSettingToggle(DebugSettingsCategory, "Show Diagnostics", false))
+{
+  CreateDiagnostic(
+    Text:           "[ {0} ]  Server Load".Format([ServerLoad()]),
+    Color:          Colors.StepGradient(gradientColors, ServerLoad()/255),
+    SortOrder:      1);
+  CreateDiagnostic(
+    Text:           "[ {0} ]  Server Load Average".Format([ServerLoadAverage()]),
+    Color:          Colors.StepGradient(gradientColors, ServerLoadAverage()/255),
+    SortOrder:      2);
+  CreateDiagnostic(
+    Text:           "[ {0} ]  Server Load Peak".Format([ServerLoadPeak()]),
+    Color:          Colors.StepGradient(gradientColors, ServerLoadPeak()/255),
+    SortOrder:      3);
+  CreateDiagnostic(
+    Text:           <"[ <0> / <1> ]  Entity Count", EntityCount(), 128>,
+    Color:          Colors.StepGradient(gradientColors, EntityCount()/128),
+    SortOrder:      4);
+  CreateDiagnostic(
+    Text:           <"[ <0> / <1> ]  Text Count", TextCount(), 128>,
+    Color:          Colors.StepGradient(gradientColors, TextCount() / 128),
+    SortOrder:      5);
+  CreateDiagnostic(
+    Text:           <"[ <0> / <1> ]  Dummy Bot Count", DummyBotCount(), 12 - HumanAndAICount()>,
+    Color:          Colors.StepGradient(gradientColors, DummyBotCount() / 12 - HumanAndAICount()),
+    SortOrder:      6);
+}
 
 globalvar Boolean INSPECTOR_DISABLED! = !WorkshopSettingToggle(DebugSettingsCategory, "Enable Inspector Recording", false);
 rule: "[main.ostw] Disable Inspector Recording" -100

--- a/main.ostw
+++ b/main.ostw
@@ -14,7 +14,7 @@ A set of tools that make custom games more useful for recreating, testing, and r
         General
         {
             Hero Limit: 1 Per Team
-            Game Mode Start: Immediately
+            Game Mode Start: Manual
             Tank Role Passive Health Bonus: Disabled
             Limit Roles: 1 Tank 2 Offense 2 Support
         }
@@ -62,7 +62,7 @@ if (INSPECTOR_DISABLED)
 rule: "[main.ostw] If start match immediately, do so"
 if (WorkshopSettingToggle(GeneralSettingsCategory, "Start Match Immediately", true))
 {
-  Wait(3);
+  Wait(2);
   StartGameMode();
 }
 
@@ -83,8 +83,9 @@ if (IsAssemblingHeroes())
 
 rule: "[main.ostw] pause match time on start of round"
 if (WorkshopSettingToggle(GeneralSettingsCategory, "Automatically Pause Match Time At Round Start", true))
-if (!IsAssemblingHeroes())
+if (IsInSetup() || IsGameInProgress())
 {
+  AbortIf(isTimePaused);
   PauseMatchTime();
   isTimePaused = true;
 }

--- a/main.ostw
+++ b/main.ostw
@@ -59,6 +59,13 @@ if (INSPECTOR_DISABLED)
   DisableInspectorRecording();
 }
 
+rule: "[main.ostw] If start match immediately, do so"
+if (WorkshopSettingToggle(GeneralSettingsCategory, "Start Match Immediately", true))
+{
+  Wait(3);
+  StartGameMode();
+}
+
 rule: "[main.ostw] Skip assembling heroes"
 if (IsAssemblingHeroes())
 {

--- a/main.ostw
+++ b/main.ostw
@@ -36,6 +36,7 @@ A set of tools that make custom games more useful for recreating, testing, and r
 import "UndoTankHealthReduction.ostw";
 import "interface/menu.ostw";
 import "lib/logs/logs.del";
+import "lib/metrics/diagnostics.del";
 
 String GeneralSettingsCategory: "01. General";
 String HeroSettingsCategory: "02. Hero Settings";
@@ -50,47 +51,6 @@ globalvar Number i;
 // DEBUG: Diagnostics
 Number DummyBotCount(): CountOf(FilteredArray(AllPlayers(), IsDummyBot(ArrayElement())));
 Number HumanAndAICount(): CountOf(FilteredArray(AllPlayers(), !IsDummyBot(ArrayElement())));
-globalvar Color[] gradientColors! = [Color.Green, Color.LimeGreen, Color.Yellow, Color.Orange, Color.Red];
-import "OSTWUtils/Colors.del";
-void CreateDiagnostic(in String Text, in Color Color, in Number SortOrder) {
-  CreateHudText(
-    VisibleTo:      HostPlayer(),
-    Subheader:      Text,
-    Location:       Location.Right,
-    SubheaderColor: Color,
-    SortOrder:      SortOrder,
-    Reevaluation:   HudTextRev.VisibleToStringAndColor,
-    Spectators:     Spectators.VisibleAlways
-  );
-}
-rule: "[DEBUG | main.ostw] Show diagnostics"
-if (WorkshopSettingToggle(DebugSettingsCategory, "Show Diagnostics", false))
-{
-  CreateDiagnostic(
-    Text:           "[ {0} ]  Server Load".Format([ServerLoad()]),
-    Color:          Colors.StepGradient(gradientColors, ServerLoad()/255),
-    SortOrder:      1);
-  CreateDiagnostic(
-    Text:           "[ {0} ]  Server Load Average".Format([ServerLoadAverage()]),
-    Color:          Colors.StepGradient(gradientColors, ServerLoadAverage()/255),
-    SortOrder:      2);
-  CreateDiagnostic(
-    Text:           "[ {0} ]  Server Load Peak".Format([ServerLoadPeak()]),
-    Color:          Colors.StepGradient(gradientColors, ServerLoadPeak()/255),
-    SortOrder:      3);
-  CreateDiagnostic(
-    Text:           <"[ <0> / <1> ]  Entity Count", EntityCount(), 128>,
-    Color:          Colors.StepGradient(gradientColors, EntityCount()/128),
-    SortOrder:      4);
-  CreateDiagnostic(
-    Text:           <"[ <0> / <1> ]  Text Count", TextCount(), 128>,
-    Color:          Colors.StepGradient(gradientColors, TextCount() / 128),
-    SortOrder:      5);
-  CreateDiagnostic(
-    Text:           <"[ <0> / <1> ]  Dummy Bot Count", DummyBotCount(), 12 - HumanAndAICount()>,
-    Color:          Colors.StepGradient(gradientColors, DummyBotCount() / 12 - HumanAndAICount()),
-    SortOrder:      6);
-}
 
 globalvar Boolean INSPECTOR_DISABLED! = !WorkshopSettingToggle(DebugSettingsCategory, "Enable Inspector Recording", false);
 rule: "[main.ostw] Disable Inspector Recording" -100


### PR DESCRIPTION
- **fix: remove countdown text when recording countdown is aborted**
- **fix: send proper action on recording countdown abort**
- **fix: stop bot replay when recording is complete**
- **feat: return player to bot editing when they end the recording**
- **fix: prevent false positive prevention of self-healing passive**
- **fix: prevent changing hero from failing when bot count is at its limit**
- **perf: improve metrics server load**
- **refactor: avoid using class-based diagnostics display**
