### PR TITLE
fix: various fixes

### DIFF
--- a/interface/dummyBotsAndReplay/botEditPage.del
+++ b/interface/dummyBotsAndReplay/botEditPage.del
@@ -377,9 +377,8 @@ void DeleteSelectedBotReplay()
       selectedBot.recordingPlayStopFlag = RecordingAction.DELETE;
       Wait(0.5);
       SmallMessage(EventPlayer(), "  Replay deleted");
-    } else {
-      OpenMenuToPage(EventPlayer(), MenuState.EDITING_DUMMY_BOT);
     }
+    OpenMenuToPage(EventPlayer(), MenuState.EDITING_DUMMY_BOT);
   } else {
     SmallMessage(EventPlayer(), "  No replay to delete");
     PlayEffect(EventPlayer(), PlayEffect.DebuffImpactSound, null, EventPlayer(), 100);

--- a/interface/dummyBotsAndReplay/botPlacementModule.ostw
+++ b/interface/dummyBotsAndReplay/botPlacementModule.ostw
@@ -40,15 +40,11 @@ if (botControlMode == BotControlMode.Edit)
 
 playervar SelectionEntity selectedControl;
 playervar Number selectionSetDistance;
-rule: "[interface/dummyBotsAndReplay/botPlacementModule.ostw] Handle left-click"
-Event.OngoingPlayer
-if (IsDummyBot() == false)
-if (botControlMode == BotControlMode.Edit)
-if (EventPlayer().IsButtonHeld(Button.PrimaryFire))
+void BotPlacementPFire() playervar "[interface/dummyBotsAndReplay/botPlacementModule.ostw] Handle left-click"
 {
-  AbortIf(!(HasSpawned() && IsAlive() && currentMenuState == MenuState.CLOSED));
+  if (!(HasSpawned() && IsAlive() && currentMenuState == MenuState.CLOSED)) return;
   selectedControl = getClosestSelectionEntity(EventPlayer());
-  AbortIf(selectedControl.Id == 0);
+  if (selectedControl.Id == 0) return;
   if (getAllMovableTargetsAsSelectionEntities().Map((e) => e.Id).Contains(selectedControl.Id)) {
     # Check if the bot is currently pinned to a position
     if (selectedControl.Owner.pinnedPosition.location != null) {
@@ -107,22 +103,15 @@ if (EventPlayer().IsButtonHeld(Button.PrimaryFire))
 }
 
 playervar Player selectedBot;
-rule: "[interface/dummyBotsAndReplay/botPlacementModule.ostw] Handle right-click"
-Event.OngoingPlayer
-if (IsDummyBot() == false)
-if (botControlMode == BotControlMode.Edit)
-if (EventPlayer().IsButtonHeld(Button.SecondaryFire))
+void BotPlacementSFire() playervar "[interface/dummyBotsAndReplay/botPlacementModule.ostw] Handle right-click"
 {
-  AbortIf(!(HasSpawned() && IsAlive() && currentMenuState == MenuState.CLOSED));
+  if (!(HasSpawned() && IsAlive() && currentMenuState == MenuState.CLOSED)) return;
   selectedControl = getClosestSelectionEntity(EventPlayer());
   if (selectedControl.Id == 0 || selectedControl.ControlType != BotControlType.DummyBot){
     selectedControl = null;
     return;
   }
   selectedBot = selectedControl.Owner;
-  # Prevent menu logic running later in the tick from assuming we meant to close the menu
-  # due to the menu state being open and a secondary fire input being detected
-  MinWait();
   OpenMenuToPage(EventPlayer(), MenuState.EDITING_DUMMY_BOT);
 }
 

--- a/interface/dummyBotsAndReplay/replay/replayDefs.del
+++ b/interface/dummyBotsAndReplay/replay/replayDefs.del
@@ -221,9 +221,9 @@ rule: "[interface/dummyBotsAndReplay/replay/replayDefs.del] When bot is in playi
 Event.OngoingPlayer
 if (replayState == ReplayState.PLAYING)
 {
-  Wait(TICK_LENGTH * playbackOffset, WaitBehavior.AbortWhenFalse);
-  for (frame = 0; totalFrames; 1) {
-    if (frame >= currentFrame.frame) {
+  // Wait(TICK_LENGTH * playbackOffset, WaitBehavior.AbortWhenFalse);
+  for (frame = -playbackOffset; totalFrames; 1) {
+    if (frame >= 0 && frame >= currentFrame.frame) {
       ProcessAllChangesInCurrentFrame();
       nextFrameIndex += 1;
       currentFrame = BigArrayAccess(recording, nextFrameIndex);

--- a/interface/menu.ostw
+++ b/interface/menu.ostw
@@ -198,11 +198,12 @@ if (currentMenuState != MenuState.CLOSED)
   if (!isNoClipActive) SetGravity(EventPlayer(), 100);
   SetAimSpeed(EventPlayer(), 100);
   # Give a leniency period for buttons to be let go of
-  Wait(0.25, WaitBehavior.RestartWhenTrue);
+  Wait(0.25);
   RemoveOneLockFromAllButtons();
   RemoveOneInvisibilityLock();
   RemoveOnePhasedOutLock();
   // ClearStatus(EventPlayer(), Status.Asleep);
+  LoopIfConditionIsTrue();
 }
 
 rule: "[interface/menu.ostw] When player holds Interact long enough, toggle menu"

--- a/interface/menu.ostw
+++ b/interface/menu.ostw
@@ -223,7 +223,14 @@ rule: "[interface/menu.ostw] Primary fire to select current item"
 Event.OngoingPlayer
 if (IsButtonHeld(EventPlayer(), Button.PrimaryFire))
 {
-  AbortIf(currentMenuState == MenuState.CLOSED);
+  AbortIf(IsControllable());
+  # Extra-menu primary fire handling
+  if (currentMenuState == MenuState.CLOSED) {
+    if (IsAlive() && playerRulerState == RulerState.PLACING) RulerHandlePFire();
+
+    if (botControlMode == BotControlMode.Edit) BotPlacementPFire();
+    return;
+  }
   AbortIf(currentActionGrid() != INTENTIONALLY_EMPTY_ACTION_GRID && currentActionItem() == 0);
   switch (currentMenuState) {
     case MenuState.MAIN_MENU:
@@ -260,7 +267,13 @@ rule: "[interface/menu.ostw] Secondary fire to go back"
 Event.OngoingPlayer
 if (IsButtonHeld(EventPlayer(), Button.SecondaryFire))
 {
-  AbortIf(currentMenuState == MenuState.CLOSED);
+  AbortIf(IsControllable());
+  if (currentMenuState == MenuState.CLOSED) {
+    if (IsAlive() && playerRulerState == RulerState.PLACING) RulerHandleSFire();
+
+    if (botControlMode == BotControlMode.Edit) BotPlacementSFire();
+    return;
+  }
   if (currentMenuState == MenuState.MAIN_MENU) {
     CloseMenu(EventPlayer());
     return;

--- a/interface/menuDefinitions.ostw
+++ b/interface/menuDefinitions.ostw
@@ -65,8 +65,8 @@ void OpenMenuToPage(in Player player = EventPlayer(), in MenuState menuState = M
 }
 
 void CloseMenu(in Player player = EventPlayer()) {
-  # Avoid having input count for something else by allowing other modules to read that an input was processed in the menu.
-  MinWait();
+  // # Avoid having input count for something else by allowing other modules to read that an input was processed in the menu.
+  // MinWait();
   player.currentMenuState = MenuState.CLOSED;
 }
 

--- a/interface/tools/ruler.ostw
+++ b/interface/tools/ruler.ostw
@@ -68,26 +68,16 @@ if (playerRulerState != RulerState.HIDDEN)
   DestroyInWorldText(rulerEffects[4]);
 }
 
-rule: "[interface/tools/ruler.ostw] Handle player setting first point"
-Event.OngoingPlayer
-if (IsAlive())
-if (playerRulerState == RulerState.PLACING)
-if (IsButtonHeld(Button: Button.PrimaryFire))
+void RulerHandlePFire() playervar "[interface/tools/ruler.ostw] Handle player setting first point"
 {
-  AbortIf(currentMenuState != MenuState.CLOSED);
   isMovingPosition1 = true;
   WaitUntil(!IsButtonHeld(Button: Button.PrimaryFire), 99999);
   isMovingPosition1 = false;
   position1 = RayCastHitPosition(EyePosition(), EyePosition() + 5 * FacingDirectionOf(), AllPlayers(), EventPlayer(), true);
 }
 
-rule: "[interface/tools/ruler.ostw] Handle player setting second point"
-Event.OngoingPlayer
-if (IsAlive())
-if (playerRulerState == RulerState.PLACING)
-if (IsButtonHeld(Button: Button.SecondaryFire))
+void RulerHandleSFire() playervar "[interface/tools/ruler.ostw] Handle player setting second point"
 {
-  AbortIf(currentMenuState != MenuState.CLOSED);
   isMovingPosition2 = true;
   WaitUntil(!IsButtonHeld(Button: Button.SecondaryFire), 99999);
   isMovingPosition2 = false;

--- a/interface/tools/toolsMenu.ostw
+++ b/interface/tools/toolsMenu.ostw
@@ -248,9 +248,8 @@ void EndGame()
       return;
     }
     SmallMessage(EventPlayer(), "Can't seem to end the game right now. Try again in a bit!");
-  } else {
-    OpenMenuToPage(EventPlayer(), MenuState.TOOLS);
   }
+  OpenMenuToPage(EventPlayer(), MenuState.TOOLS);
 }
 
 void ToggleRuler()

--- a/lib/quickActions/globalTriggers.del
+++ b/lib/quickActions/globalTriggers.del
@@ -24,6 +24,7 @@ if(IsControllable() == false)
 if(IsAlive() && has_triggers())
 if(anyTriggersHeld(_watch_triggers))
 {
+    AbortIf(currentMenuState != MenuState.CLOSED);
     foreach(Trigger t in _watch_triggers) {
         if (t.isTriggerHeld())
         {


### PR DESCRIPTION
- **fix: properly return to bot editing page after deleting replay**
- **refactor: consolidate primary and secondary fire handlers**
- **fix: prevent reopening menu quickly from causing state cleanup to not fire**
- **fix: prevent playback offset from being one tick off**
- **perf: remove unnecessary delay on exiting menu**
- **fix: if ending game fails, return to tools menu**
- **fix: prevent triggers from being used in-menu**
